### PR TITLE
FORMS-201 # date views (native + picker) broken after AMD module rest…

### DIFF
--- a/forms/jqm/elements/date.js
+++ b/forms/jqm/elements/date.js
@@ -70,6 +70,17 @@ define(function (require) {
       return this;
     },
 
+    onAttached: function () {
+      var type = this.model.get('type');
+
+      if (type !== 'time') {
+        this.onDateMChange();
+      }
+      if (type !== 'date') {
+        this.onTimeMChange();
+      }
+    },
+
     onDateVChange: function (event) {
       this.model.set('_date', $(event.target).val());
     },

--- a/forms/jqm/elements/date_pickadate.js
+++ b/forms/jqm/elements/date_pickadate.js
@@ -147,7 +147,10 @@ define(function (require) {
         settings = {};
 
       settings.format = this.mapTimeFormats[attr.timeFormat] || "HH:i";
-      if (attr.minuteStep) {
+      //pickatime slows down things, when interval is small
+      //default interval is 1, and setting it explicit to 1 slows down things
+      //so if minute step is one don't set it and let it pick default
+      if (attr.minuteStep && parseInt(attr.minuteStep, 10) !== 1) {
         settings.interval = parseInt(attr.minuteStep, 10);
       }
       settings.container = DatePickadateElement.pickadateParent;
@@ -169,16 +172,22 @@ define(function (require) {
     },
 
     onAttached: function () {
+      var self = this;
       var type = this.model.attributes.type;
       var name = this.model.attributes.name;
       var date$, time$;
+      DateView.prototype.onAttached.call(this);
       if (type !== 'time') {
         date$ = this.$el.find('input[name=' + name + '_date]');
         date$.pickadate(this.prepareDateSettings());
       }
       if (type !== 'date') {
         time$ = this.$el.find('input[name=' + name + '_time]');
-        time$.pickatime(this.prepareTimeSettings());
+        //slows down rending if interval is set to small number
+        //so set timeout
+        setTimeout(function() {
+          time$.pickatime(self.prepareTimeSettings());
+        }, 0);
       }
     }
 

--- a/forms/models/elements/date.js
+++ b/forms/models/elements/date.js
@@ -41,7 +41,7 @@ define([
             dateValue = moment(Date.parse(attr.defaultDateDate));
           }
           if (dateValue !== null) {
-            this.set('value', dateValue.format(dateFormat));
+            this.set('_date', dateValue.format(dateFormat));
           }
           break;
         case 'time':
@@ -52,7 +52,7 @@ define([
             timeValue = moment().add(parseInt(attr.nowPlusAmount, 10), 'm');
           }
           if (timeValue !== null) {
-            this.set('value', timeValue.format(timeFormat));
+            this.set('_time', timeValue.format(timeFormat));
           }
           break;
         case 'datetime':

--- a/test/1_date_time/test.js
+++ b/test/1_date_time/test.js
@@ -21,7 +21,67 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
     'datetimenow'
   ];
 
+  function defineModelToViewTests() {
+    test('model->value', function (done) {
+      setTimeout(function() {
+        Forms.current.get('elements').forEach(function (el) {
+          var value = el.val();
+          var name = el.get('name');
+          var time = el.get('_time');
+          var time$ = el.get('_view').$el.find('input[name$=_time]');
+          var date$ = el.get('_view').$el.find('input[name$=_date]');
+          var date = el.get('_date');
+          var type = el.get('type');
+          if (value && !el.get('readonly')) {
+            if (type !== 'time') {
+              assert.lengthOf(date$, 1, name + ': has DOM date');
+              assert.equal(date$.val(), date, name + ': DOM date value');
+            }
+            if (type !== 'date') {
+              assert.lengthOf(time$, 1, name + ': has DOM time');
+              assert.equal(time$.val(), time, name + ': DOM time value');
+            }
+          }
+        });
+        done();
+      }, 1e3);
+    });
+  }
 
+  function defineViewToModelTests() {
+    test('view->model', function (done) {
+      setTimeout(function() {
+        Forms.current.get('elements').forEach(function (el) {
+          var date;
+          var time;
+          var value = el.val();
+          var name = el.get('name');
+          var time$ = el.get('_view').$el.find('input[name$=_time]');
+          var date$ = el.get('_view').$el.find('input[name$=_date]');
+          var type = el.get('type');
+          if (value && !el.get('readonly')) {
+            if (type !== 'time') {
+              date = "2015-06-10";
+              date$.val(date);
+              date$.trigger('change');
+              assert.lengthOf(date$, 1, name + ': has DOM date');
+              assert.equal(date$.val(), date, name + ': DOM date value');
+              assert.equal(date$.val(), el.get('_date'), name + ': _date value');
+            }
+            if (type !== 'date') {
+              time = "10:00";
+              time$.val(time);
+              time$.trigger('change');
+              assert.lengthOf(time$, 1, name + ': has DOM time');
+              assert.equal(time$.val(), time, name + ': DOM time value');
+              assert.equal(time$.val(), el.get('_time'), name + ': _time value');
+            }
+          }
+        });
+        done();
+      }, 1e3);
+    });
+  }
 
   suite('1: date/time', function () {
     var $page = $('[data-role=page]'),
@@ -68,6 +128,27 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
       });
 
       testUtils.defineLabelTest();
+
+      test('all now and now_plus models have non-empty values', function () {
+        Forms.current.get('elements').forEach(function (el) {
+          var defaultValue = el.get('defaultValue');
+          if (defaultValue && defaultValue.indexOf('now') !== -1) {
+            assert.ok(el.val(), el.get('name') + ': non-empty');
+          }
+        });
+      });
+
+      test('all models with no default have non-empty values', function () {
+        Forms.current.get('elements').forEach(function (el) {
+          var defaultValue = el.get('defaultValue');
+          if (!defaultValue) {
+            assert.notOk(el.val(), el.get('name') + ': empty');
+          }
+        });
+      });
+
+      defineModelToViewTests();
+      defineViewToModelTests();
 
       test('use datetime field - avoid undefined', function () {
         var form = Forms.current,
@@ -191,6 +272,8 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
           });
         });
 
+        defineModelToViewTests();
+        defineViewToModelTests();
       });
 
     }); // END: suite('Form', ...)


### PR DESCRIPTION
…ructure
- date.model: for date and time field use same method as datetime to set value
- date.view: on Attached Method, that calls onModelChange()
- date.pickadate.view:
  -- avoid setting interval if its 1, small intervals makes element rendering slow
  -- pickatime to be async
- tests to confirm view->model and model->view value assignment happens properly
