### PR TITLE
FORMS-189 # Native Date picker NOW, NOW + does not show value

### DIFF
--- a/forms/models/elements/date.js
+++ b/forms/models/elements/date.js
@@ -12,6 +12,24 @@ define([
         dateValue = null,
         timeValue = null;
 
+      //native date field requires RFC3339
+      //http://stackoverflow.com/questions/6982692/html5-input-type-date-default-value-to-today
+      if (attr.nativeDatetimePicker) {
+        attr.nativeDatetimePicker = parseInt(attr.nativeDatetimePicker, 10);
+        if (attr.nativeDatetimePicker === 1) {
+          attr.dateFormat = "YYYY-MM-DD";
+        }
+      }
+      if (attr.nativeDatePicker) {
+        attr.nativeDatePicker = parseInt(attr.nativeDatePicker, 10);
+        if (attr.nativeDatePicker === 1) {
+          attr.dateFormat = "YYYY-MM-DD";
+        }
+      }
+      if (attr.nativeTimePicker) {
+        attr.nativeTimePicker = parseInt(attr.nativeTimePicker, 10);
+      }
+
       /* THIS CODE NEEDS TO BE REMOVED WITH PLATFORM 2.26+ */
       if (attr.picker) {
         switch(attr.picker) {
@@ -87,9 +105,9 @@ define([
       if (attr.readonly) {
         View = Forms._views.ReadOnlyElement;
         view = new View({model: this});
-      } else if (parseInt(attr.nativeDatetimePicker, 10) === 1
-          || parseInt(attr.nativeDatePicker, 10) === 1
-          || parseInt(attr.nativeTimePicker, 10) === 1) {
+      } else if (attr.nativeDatetimePicker === 1
+          || attr.nativeDatePicker === 1
+          || attr.nativeTimePicker === 1) {
         view = new Forms._views.DateElement({model: this});
       } else {
         view = new Forms._views.DatePickadateElement({model: this});

--- a/test/1_date_time/definitions.js
+++ b/test/1_date_time/definitions.js
@@ -620,13 +620,13 @@ define(function () {
             "add": {
               "labelPlacement": "default",
               "labelStyle": "Plain",
-              "dateFormat": "dd_mm_yyyy",
+              "dateFormat": "yyyy_mm_dd",
               "timeFormat": "hh_mm"
             },
             "edit": {
               "labelPlacement": "default",
               "labelStyle": "Plain",
-              "dateFormat": "dd_mm_yyyy",
+              "dateFormat": "yyyy_mm_dd",
               "timeFormat": "hh_mm"
             },
             "view": {
@@ -738,6 +738,59 @@ define(function () {
               "labelStyle": "Plain",
               "dateFormat": "dd_mm_yyyy",
               "timeFormat": "hh_mm"
+            }
+          },
+          {
+            "default": {
+              "name": "dateTimeNativePickerNow",
+              "type": "datetime",
+              "label": "Date Time Native Picker Now",
+              "labelPlacement": "default",
+              "labelStyle": "Plain",
+              "picker": "picker",
+              "dateFormat": "mm_dd_yyyy",
+              "timeFormat": "hh_mm",
+              "defaultTimestamp": "now",
+              "minuteStep": "1",
+              "defaultValue": "now",
+              "page": 0,
+              "nativeDatetimePicker": "1"
+            }
+          },
+          {
+            "default": {
+              "name": "dateTimeNativePickerNowP",
+              "type": "datetime",
+              "label": "Date Time Native Picker NowP +1day",
+              "labelPlacement": "default",
+              "labelStyle": "Plain",
+              "picker": "picker",
+              "dateFormat": "mm_dd_yyyy",
+              "timeFormat": "hh_mm",
+              "defaultTimestamp": "now_plus",
+              "nowPlusAmount": "1440",
+              "minuteStep": "1",
+              "defaultValue": "now_plus",
+              "page": 0,
+              "nativeDatetimePicker": "1"
+            }
+          },
+          {
+            "default": {
+              "name": "dateTimeNativePckerNowPM",
+              "type": "datetime",
+              "label": "Date Time Native Picker NowP -2day",
+              "labelPlacement": "default",
+              "labelStyle": "Plain",
+              "picker": "picker",
+              "dateFormat": "mm_dd_yyyy",
+              "timeFormat": "hh_mm",
+              "defaultTimestamp": "now_plus",
+              "nowPlusAmount": "-2880",
+              "minuteStep": "1",
+              "defaultValue": "now_plus",
+              "page": 0,
+              "nativeDatetimePicker": "1"
             }
           }
         ]

--- a/test/1_date_time/test.js
+++ b/test/1_date_time/test.js
@@ -276,6 +276,35 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
         defineViewToModelTests();
       });
 
+
+      suite('native, date assignment', function () {
+        var native = [
+          //'dateTimeNativePickerNone',
+          'dateTimeNativePickerNow',
+          'dateTimeNativePickerNowP',
+          'dateTimeNativePckerNowPM'
+        ];
+
+        test('check if date fields have correct values', function () {
+          var form = Forms.current,
+            element,
+            $fieldset,
+            $input;
+
+          native.forEach(function(fld) {
+            element = form.getElement(fld);
+            $fieldset = element.attributes._view.$el;
+            //should contain date field
+            $input = $fieldset.find("input[type='date']");
+            assert.equal($input.length, 1);
+            assert($input.val(), "no value assigned to $input");
+          });
+        });
+
+        defineModelToViewTests();
+        defineViewToModelTests();
+      });
+
     }); // END: suite('Form', ...)
 
   }); // END: suite('1', ...)


### PR DESCRIPTION
- for native date picker always use YYYY-MM-DD format
- convert native picker value to numeric once and use it everywhere
- tests to confirm input fields have same value as model
- tests to confirm view->model and model->view works as expected
