### PR TITLE
FORMS-206 # choice fields that are required but not-empty block validation

### DIFF
--- a/forms/jqm/elements/choicecollapsed.js
+++ b/forms/jqm/elements/choicecollapsed.js
@@ -120,6 +120,8 @@ define(function (require) {
           this.$el.find('input[type = text]').val(_.difference(attr.value, _.keys(attr.options)));
         }
       }
+      this.model.isValid();
+      this.renderErrors(this.model);
     },
 
     fetchValue: function () {

--- a/forms/jqm/elements/choiceexpanded.js
+++ b/forms/jqm/elements/choiceexpanded.js
@@ -150,6 +150,8 @@ define(function (require) {
       if (_.difference(value, _.keys(model.attributes.options)).length > 0) {
         view.$el.find('input[type = text]').val(_.difference(value, _.keys(model.attributes.options)));
       }
+      this.model.isValid();
+      this.renderErrors(this.model);
     },
 
     onSelectValueChange: function () {
@@ -179,6 +181,8 @@ define(function (require) {
         // Also need to fill the text box back in, in addition to selecting radio
         this.$el.find('input[type = text]').val(this.model.get('value'));
       }
+      this.model.isValid();
+      this.renderErrors(this.model);
     },
 
     fetchValue: function () {

--- a/test/2_choices/definitions.js
+++ b/test/2_choices/definitions.js
@@ -212,6 +212,66 @@ define(function () {
                 g: 'gamma'
               }
             }
+          },
+          {
+            'default': {
+              name: 'multicollapsedrequired',
+              label: 'Multi collapsed Required',
+              type: 'multi',
+              mode: 'collapsed',
+              required: "1",
+              other: false,
+              options: {
+                a: 'alpha',
+                b: 'beta',
+                g: 'gamma'
+              }
+            }
+          },
+          {
+            'default': {
+              name: 'multiexpandedrequired',
+              label: 'Multi Expanded Required',
+              type: 'multi',
+              mode: 'expanded',
+              required: "1",
+              other: false,
+              options: {
+                a: 'alpha',
+                b: 'beta',
+                g: 'gamma'
+              }
+            }
+          },
+          {
+            'default': {
+              name: 'selectcollapsedrequired',
+              label: 'select collapsed Required',
+              type: 'select',
+              mode: 'collapsed',
+              required: "1",
+              other: false,
+              options: {
+                a: 'alpha',
+                b: 'beta',
+                g: 'gamma'
+              }
+            }
+          },
+          {
+            'default': {
+              name: 'selectexpandedrequired',
+              label: 'Select Expanded Required',
+              type: 'select',
+              mode: 'expanded',
+              required: "1",
+              other: false,
+              options: {
+                a: 'alpha',
+                b: 'beta',
+                g: 'gamma'
+              }
+            }
           }
         ]
       }

--- a/test/2_choices/test.js
+++ b/test/2_choices/test.js
@@ -1,7 +1,7 @@
 /*eslint-env mocha*/
 /*global assert*/ // chai
 
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils', 'underscore', 'BIC'], function (Forms, testUtils, _) {
 
   var originalOptions = { a: 'alpha', b: 'beta', g: 'gamma' };
   var newOptions = { d: 'delta', e: 'epsilon', z: 'zeta' };
@@ -492,6 +492,33 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
         radio.set('value', "test");
         assert.equal($radEl.find('input[type="text"]').length, 0, "textbox for radios is visible");
 
+      });
+
+      suite('FORMS-206 # choice fields that are required but not-empty still block validation', function () {
+        var form,
+          element,
+          fields = {
+            'multicollapsedrequired': ["a"],
+            'multiexpandedrequired': ["a"],
+            'selectcollapsedrequired': "a",
+            'selectexpandedrequired': "a"
+          };
+
+        suiteSetup(function () {
+          form = Forms.current;
+        });
+
+        _.each(fields, function(v, k) {
+          test(k, function (done) {
+            element = form.getElement(k);
+            assert.equal(element.attributes._view.$el.children('ul').children('li').length, 1);
+            element.set('value', v);
+            assert.equal(element.attributes._view.$el.children('ul').children('li').length, 0);
+            element.set('value', null);
+            assert.equal(element.attributes._view.$el.children('ul').children('li').length, 1);
+            done();
+          });
+        });
       });
 
     }); // END: suite('Form', ...)


### PR DESCRIPTION
- choice collapsed/expanded: call validation and render errors explicitly
- tests to confirm the field errors gets rendered and gets removed on field change
