### PR TITLE
FORMS-219 # (Sub)FormView#remove() really cleans!

### DIFF
--- a/forms/jqm/form.js
+++ b/forms/jqm/form.js
@@ -24,8 +24,15 @@ define(function (require) {
     },
 
     remove: function () {
+      var pages = this.model.attributes.pages;
+
       events.proxyUnbindFormElementEvents(this, this.model, this.formElementEvents);
       this.$el.removeData('model');
+
+      if (pages && pages.current && pages.current.attributes._view) {
+        pages.current.attributes._view.remove();
+      }
+
       this.model.unset('_view');
       this.stopListening(this.model.get('elements'));
 

--- a/test/33_pages_with_subforms/test.js
+++ b/test/33_pages_with_subforms/test.js
@@ -1,7 +1,7 @@
-/*eslint-env mocha*/
-/*global assert*/ // chai
+/* eslint-env mocha */
+/* global assert */ // chai
 
-define(['BlinkForms', 'BIC'], function (Forms) {
+define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
   suite('33: Pages with subforms', function () {
     var $page, $content, form;
@@ -74,6 +74,8 @@ define(['BlinkForms', 'BIC'], function (Forms) {
         });
       });
 
+      testUtils.defineButtonTest();
+
       suite('change page', function () {
         suiteSetup(function () {
 
@@ -89,6 +91,9 @@ define(['BlinkForms', 'BIC'], function (Forms) {
             assert.notStrictEqual(labelText, '');
           });
         });
+
+        testUtils.defineButtonTest();
+
       });
     });
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -11,6 +11,12 @@ define(['BlinkForms'], function (Forms) {
 
   return {
 
+    defineButtonTest: function () {
+      test('jQM buttons displayed correctly', function () {
+        assert.lengthOf($('.ui-btn .ui-btn'), 0, 'no buttons within buttons');
+      });
+    },
+
     defineLabelTest: function () {
       test('labels displayed correctly', function () {
         Forms.current.get('elements').forEach(function (el) {


### PR DESCRIPTION
- `FormView#remove()` now calls `Page#remove()`, so that `Element#remove()` actually gets called
- this means turning the page actually causes SubFormsViews to discard their ElementViews
- importantly, this means that elements within SubForms do not get double-enhanced, e.g. signature buttons
