### PR TITLE
FORMS-203 # debounce #onKeyDown() safely

### DIFF
--- a/forms/jqm/elements/html.js
+++ b/forms/jqm/elements/html.js
@@ -12,6 +12,8 @@ define(function (require) {
 
   // this module
 
+  var KEYDOWN_DEBOUNCE = 1000; // ms
+
   return ElementView.extend({
 
     events: {
@@ -26,7 +28,19 @@ define(function (require) {
       'change:value': 'onValueChange'
     }),
 
+    initialize: function () {
+      ElementView.prototype.initialize.apply(this, arguments);
+
+      // create an instance-specific #onKeyDown() that is debounced
+      this.onKeyDown = _.debounce(this.onKeyDown, KEYDOWN_DEBOUNCE);
+    },
+
     render: function () {
+      // Backbone.View automatically calls #delegateEvents()
+      // we call it again here, so that our debounced #onKeyDown is hooked up
+      // otherwise the raw #onKeyDown will be used instead
+      this.delegateEvents();
+
       this.renderLabel();
       if (!this.$input) {
         this.$input = this.createElement();
@@ -50,7 +64,7 @@ define(function (require) {
       return ElementView.prototype.remove.apply(this, arguments);
     },
 
-    onKeyDown: _.throttle(function (event) {
+    onKeyDown: function (event) {
       var prev = this.model.attributes.value;
       var next = $(event.target).val();
       if (next !== prev) {
@@ -58,7 +72,7 @@ define(function (require) {
         this.model.trigger('change:value');
         this.model.trigger('change', this.model);
       }
-    }, 500),
+    },
 
     onPlaceholderChange: function () {
       var text;

--- a/test/5_validation/test.js
+++ b/test/5_validation/test.js
@@ -398,7 +398,45 @@ define([
         listenerSpy.reset();
 
       });
-    }); // END: suite('Form', ...)
+    }); // END: suite('Validation', ...)
+
+    suite('onKeyDown vs performance', function () {
+
+      test('HTMLInput views have per-instance #onKeyDown()', function () {
+        Forms.current.attributes.elements
+        .filter(function (el) {
+          return [
+            'email', 'number', 'password', 'telephone', 'text', 'textarea', 'url'
+          ].indexOf(el.attributes.type) !== -1;
+        })
+        .filter(function (el) {
+          return !!el.attributes._view;
+        })
+        .forEach(function (el) {
+          var view = el.attributes._view;
+          assert.isFunction(view.onKeyDown, el.id + ' has #onKeyDown()');
+          assert.notStrictEqual(
+            view.onKeyDown,
+            view.constructor.prototype.onKeyDown,
+            el.id + '\'s #onKeyDown() is not from prototype'
+          );
+        });
+      });
+
+      test('#onKeyDown() is debounced', function (done) {
+        var el = Forms.current.getElement('textBox1');
+        var input$ = el.attributes._view.$el.find('input');
+        var VALUE = 'debounced?';
+        input$.val(VALUE);
+        input$.trigger('change');
+        assert.notEqual(el.val(), VALUE, 'changes do NOT take immediate effect');
+        setTimeout(function () {
+          assert.equal(el.val(), VALUE, 'changes DO eventually take effect');
+          done();
+        }, 1500);
+      });
+
+    });
 
     elements = ['textBox1', 'number1', 'password1', 'text', 'url', 'email', 'password', 'streetAddress', 'city', 'telephone', 'number', 'currency', 'select', 'multi'];
     /* 'heading', 'message', 'comments', 'names' */


### PR DESCRIPTION
- don't throttle unsafely on the prototype, as this means some Elements will completely miss out on updates during busy moments
- create a per-instance copy of `#onKeyDown()` that is debounced
- re-run `Backbone.View#delegateEvents()`, causing the non-debounced `#onKeyDown()` to be unhooked and the new debounced version to replace it as the event handler
## result: iPad 2 with iOS 7.1
- typing a word or sentence evenly / quickly is less likely to be interrupted with validation
