### PR TITLE
(refactor) extract form loading steps from tests

### DIFF
--- a/test/10_blinkgap/test.js
+++ b/test/10_blinkgap/test.js
@@ -4,9 +4,7 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
   suite('10: blinkgap', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]'),
-      getDrawingStub,
+    var getDrawingStub,
       getPictureStub,
       getDrawingFn;
 
@@ -50,46 +48,9 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
       getPictureStub = window.sinon.stub(navigator.camera, 'getPicture',
         getDrawingFn);
       window.PictureSourceType = {};
-
-      $content.empty();
-      delete Forms.current;
     });
 
-    suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-    }); // END: suite('Form', ...)
+    testUtils.defineFormLoadSuite('form1', 'add');
 
     suite('Drawing', function () {
 

--- a/test/10_blinkgap/test.js
+++ b/test/10_blinkgap/test.js
@@ -1,7 +1,7 @@
 
 /*global assert:true*/ // chai
 
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   suite('10: blinkgap', function () {
     var getDrawingStub,

--- a/test/11_rating/test.js
+++ b/test/11_rating/test.js
@@ -1,7 +1,7 @@
 
 /*global assert:true*/ // chai
 
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('form1', 'add');
 

--- a/test/11_rating/test.js
+++ b/test/11_rating/test.js
@@ -3,53 +3,11 @@
 
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
+  testUtils.defineFormLoadSuite('form1', 'add');
+
   suite('11: rating', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-    });
-
-    suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-    }); // END: suite('Form', ...)
+    test('');
 
   }); // END: suite('1', ...)
 

--- a/test/12_rivets/test.js
+++ b/test/12_rivets/test.js
@@ -1,4 +1,4 @@
-define(['jquery', 'BlinkForms', 'testUtils', 'BIC'], function ($, Forms, testUtils) {
+define(['jquery', 'BlinkForms', 'testUtils'], function ($, Forms, testUtils) {
   'use strict';
 
   testUtils.defineFormLoadSuite('form1', 'add');

--- a/test/12_rivets/test.js
+++ b/test/12_rivets/test.js
@@ -1,58 +1,9 @@
 define(['jquery', 'BlinkForms', 'testUtils', 'BIC'], function ($, Forms, testUtils) {
   'use strict';
 
+  testUtils.defineFormLoadSuite('form1', 'add');
+
   suite('12: rivets / data-binding', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
-
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-    });
-
-    suite('Form', function () {
-      var definition;
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('Forms.getDefinition()', function (done) {
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          definition = def;
-          assert(true, 'getDefinition succeeded!');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('Forms.initialize(definition)', function () {
-        var form;
-        Forms.initialize(definition);
-        form = Forms.current;
-        assert.equal($.type(form), 'object');
-        assert.equal(form.get('name'), 'form1');
-        assert.equal(form.get('label'), 'Form 1');
-      });
-
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-    }); // END: suite('Form', ...)
 
     suite('DOM Bindings', function () {
 

--- a/test/13_date_time_pages/test.js
+++ b/test/13_date_time_pages/test.js
@@ -1,123 +1,75 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
-  suite('9: pages', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('form1', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  suite('13: date/time, pages', function () {
+
+    test('starts at page 0', function () {
+      var form = Forms.current,
+        pages = form.attributes.pages,
+        page = pages.current;
+
+      assert.equal(page.index(), 0);
     });
 
-    suite('Form', function () {
+    test('page 0 elements are visible', function () {
+      var form = Forms.current,
+        names = ['url', 'email', 'password'];
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
+      names.forEach(function (name) {
+        var element = form.getElement(name),
+          view = element.get('_view');
+
+        assert.isTrue(view.$el.is(':visible'), name + ' is visible');
       });
+    });
 
-      test('initialise with form.json', function (done) {
-        var form;
+    test('page 1,2 elements are not present', function () {
+      var form = Forms.current,
+        names = ['streetAddress', 'city', 'telephone', 'number', 'currency'];
 
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
+      names.forEach(function (name) {
+        var element = form.getElement(name),
+          view = element.get('_view');
+
+        assert(!view, name + ' is not present');
       });
+    });
 
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
+    test('go t page 2 and check datepicker element', function (done) {
+      var form = Forms.current,
+        pages = form.attributes.pages,
+        page,
+        element,
+        view,
+        $input,
+        picker;
 
-        $content.append(form.$form);
+      pages.goto(2);
+      page = pages.current;
+      assert.equal(page.index(), 2);
 
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
+      element = form.getElement('datefromdate');
+      view = element.get('_view');
+      $input = view.$el.find('input');
+      assert.equal($input.hasClass('picker__input'), true);
+      $input.trigger('click');
+      setTimeout(function () {
+        assert.equal($input.hasClass('picker__input--active'), true);
+        picker = $('div[class="picker__holder"]');
+        picker.trigger('click');
+        done();
+      }, 500);
 
-      testUtils.defineLabelTest();
+      // assert.equal($input.hasClass('picker__input'), true);
+    });
 
-    }); // END: suite('Form', ...)
+    test('all [data-role=fieldcontain] enhanced', function () {
+      var fieldcontain$ = $('[data-role=fieldcontain]');
+      var enhanced$ = $('[data-role=fieldcontain].ui-field-contain');
+      assert.equal(fieldcontain$.length, enhanced$.length);
+    });
 
-    suite('Pages', function () {
-
-      test('starts at page 0', function () {
-        var form = Forms.current,
-          pages = form.attributes.pages,
-          page = pages.current;
-
-        assert.equal(page.index(), 0);
-      });
-
-      test('page 0 elements are visible', function () {
-        var form = Forms.current,
-          names = ['url', 'email', 'password'];
-
-        names.forEach(function (name) {
-          var element = form.getElement(name),
-            view = element.get('_view');
-
-          assert.isTrue(view.$el.is(':visible'), name + ' is visible');
-        });
-      });
-
-      test('page 1,2 elements are not present', function () {
-        var form = Forms.current,
-          names = ['streetAddress', 'city', 'telephone', 'number', 'currency'];
-
-        names.forEach(function (name) {
-          var element = form.getElement(name),
-            view = element.get('_view');
-
-          assert(!view, name + ' is not present');
-        });
-      });
-
-      test('go t page 2 and check datepicker element', function (done) {
-        var form = Forms.current,
-          pages = form.attributes.pages,
-          page,
-          element,
-          view,
-          $input,
-          picker;
-
-        pages.goto(2);
-        page = pages.current;
-        assert.equal(page.index(), 2);
-
-        element = form.getElement('datefromdate');
-        view = element.get('_view');
-        $input = view.$el.find('input');
-        assert.equal($input.hasClass('picker__input'), true);
-        $input.trigger('click');
-        setTimeout(function () {
-          assert.equal($input.hasClass('picker__input--active'), true);
-          picker = $('div[class="picker__holder"]');
-          picker.trigger('click');
-          done();
-        }, 500);
-
-        // assert.equal($input.hasClass('picker__input'), true);
-      });
-
-      test('all [data-role=fieldcontain] enhanced', function () {
-        var fieldcontain$ = $('[data-role=fieldcontain]');
-        var enhanced$ = $('[data-role=fieldcontain].ui-field-contain');
-        assert.equal(fieldcontain$.length, enhanced$.length);
-      });
-
-    }); // END: suite('Pages', ...)
-
-  }); // END: suite('1', ...)
+  }); // END: suite('Pages', ...)
 
 });

--- a/test/13_date_time_pages/test.js
+++ b/test/13_date_time_pages/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('form1', 'add');
 

--- a/test/14_header_footer/test.js
+++ b/test/14_header_footer/test.js
@@ -1,64 +1,20 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
-  suite('14: Forms Header/Footer', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('form1', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  suite('14: Forms Header/Footer', function () {
+
+    test('render form with header and footer', function () {
+      var form = Forms.current,
+        header = form.attributes._view.$el.find('header'),
+        footer = form.attributes._view.$el.find('footer');
+
+      assert(header);
+      assert.equal(header.text(), 'Heading........');
+      assert(footer);
+      assert.equal(footer.text(), 'Footer........');
     });
 
-    suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-      test('render form with header and footer', function () {
-        var form = Forms.current,
-          header = form.attributes._view.$el.find('header'),
-          footer = form.attributes._view.$el.find('footer');
-
-        assert(header);
-        assert.equal(header.text(), 'Heading........');
-        assert(footer);
-        assert.equal(footer.text(), 'Footer........');
-      });
-
-    }); // END: suite('Form', ...)
-
-  }); // END: suite('1', ...)
+  }); // END: suite('Form', ...)
 
 });

--- a/test/14_header_footer/test.js
+++ b/test/14_header_footer/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('form1', 'add');
 

--- a/test/15_renderSubForm/test.js
+++ b/test/15_renderSubForm/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('Test', 'add');
 

--- a/test/15_renderSubForm/test.js
+++ b/test/15_renderSubForm/test.js
@@ -1,113 +1,189 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
-  suite('15: subForms render', function () {
-    var $doc = $(document),
-      $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('Test', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  suite('15: subForms render', function () {
+
+    test('Edit form with subforms', function (done) {
+      var form = Forms.current;
+      var element = {
+        id: '37',
+        Name: 'Greg',
+        Address: [
+          {
+            "id": "39",
+            "Detail": "David",
+            "_action": "edit"
+          },
+          {
+            "id": "40",
+            "Detail": "Andrew",
+            "_action": "edit"
+          },
+          {
+            "id": "41",
+            "Detail": "Harry",
+            "_action": "edit"
+          }
+        ]
+      };
+      $.ajax({
+        type: "GET",
+        url: "getformrecord.xml",
+        dataType: "xml"}).then(
+        function (data) {
+          var record = {}, node, nodes;
+          nodes = data.evaluate('//' + form.attributes.name, data);
+          node = nodes.iterateNext();
+          _.each(node.children, function (key) {
+            record[key.nodeName] = key.innerHTML;
+          });
+
+          form.setRecord(record).then(function () {
+            form.data().then(function (formdata) {
+              var keys = _.keys(record);
+              _.each(keys, function (k) {
+                assert.deepEqual(formdata[k], element[k]);
+                assert.ok(formdata[k], k + " does not exist");
+              });
+              done();
+            }, function () {
+              assert(false, "failed to set record");
+              done();
+            });
+          });
+        }
+     );
     });
 
-    suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('Test', 'add').then(function (def) {
-          Forms.initialize(def, 'add');
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'Test');
-          assert.equal(form.get('label'), 'Test');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function (done) {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $doc.one('pageinit', function () {
-          done();
-        });
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-      test('Edit form with subforms', function (done) {
-        var form = Forms.current;
-        var element = {
-          id: '37',
-          Name: 'Greg',
+    test('form with subform', function (done) {
+        var result;
+        var xml = "<Address><Address><id>1</id><Detail>what a whiner</Detail></Address><Address><id>2</id><Detail>great day</Detail></Address><Address><id>3</id><Detail>great food</Detail></Address></Address>";
+        var record = {
           Address: [
             {
-              "id": "39",
-              "Detail": "David",
-              "_action": "edit"
+              id: "1",
+              Detail: 'what a whiner'
             },
             {
-              "id": "40",
-              "Detail": "Andrew",
-              "_action": "edit"
+              id: "2",
+              Detail: 'great day'
             },
             {
-              "id": "41",
-              "Detail": "Harry",
-              "_action": "edit"
+              id: "3",
+              Detail: 'great food'
             }
+
           ]
         };
-        $.ajax({
-          type: "GET",
-          url: "getformrecord.xml",
-          dataType: "xml"}).then(
-          function (data) {
-            var record = {}, node, nodes;
-            nodes = data.evaluate('//' + form.attributes.name, data);
-            node = nodes.iterateNext();
-            _.each(node.children, function (key) {
-              record[key.nodeName] = key.innerHTML;
-            });
+        xml = $.parseXML(xml);
+        xml = xml.firstElementChild || xml.documentElement;
+        result = Forms._models.Form.xmlToJson(xml, {});
+        assert.deepEqual(record, result);
+        done();
+    });
 
-            form.setRecord(record).then(function () {
-              form.data().then(function (formdata) {
-                var keys = _.keys(record);
-                _.each(keys, function (k) {
-                  assert.deepEqual(formdata[k], element[k]);
-                  assert.ok(formdata[k], k + " does not exist");
-                });
-                done();
-              }, function () {
-                assert(false, "failed to set record");
-                done();
-              });
-            });
-          }
-       );
-      });
+    test('subform with subform', function (done) {
+        var result;
+        var xml = "<Address><Address><id>51</id><Detail>Great work</Detail><Exp><Exp><id>1</id><Rank>45</Rank></Exp></Exp></Address><Address><id>52</id><Detail>Bad news</Detail><Exp><Exp><id>2</id><Rank>89</Rank></Exp><Exp><id>3</id><Rank>88</Rank></Exp></Exp></Address><Address><id>53</id><Detail>Quite Day</Detail><Exp/></Address></Address>";
+        var record = {
+          Address: [
+            {
+              id: '51',
+              Detail: 'Great work',
+              Exp: [
+                {
+                  id: '1',
+                  Rank: '45'
+                }
+              ]
+            },
+            {
+              id: '52',
+              Detail: 'Bad news',
+              Exp: [
+                {
+                  id: '2',
+                  Rank: '89'
+                },
+                {
+                  id: '3',
+                  Rank: '88'
+                }
+              ]
+            },
+            {
+              id: '53',
+              Detail: 'Quite Day',
+              Exp: ''
+            }
+
+          ]
+        };
+        xml = $.parseXML(xml);
+        xml = xml.firstElementChild || xml.documentElement;
+        result = Forms._models.Form.xmlToJson(xml, {});
+        assert.deepEqual(record, result);
+        done();
+    });
+
+    test('subforms with further subforms', function (done) {
+        var result;
+        var xml = "<Address><Address><id>51</id><Detail>Great work</Detail><Exp><Exp><id>1</id><Rank>45</Rank><Status/></Exp></Exp></Address><Address><id>52</id><Detail>Bad news</Detail><Exp><Exp><id>2</id><Rank>89</Rank><Status><Status><Age>45</Age></Status></Status></Exp><Exp><id>3</id><Rank>88</Rank><Status/></Exp></Exp></Address><Address><id>53</id><Detail>Quite Day</Detail><Exp/></Address></Address>";
+        var record = {
+            "Address": [
+                {
+                  id: "51",
+                  Detail: "Great work",
+                  Exp: [
+                    {
+                      id: "1",
+                      Rank: "45",
+                      Status: ""
+                    }
+                  ]
+                },
+                {
+                  id: "52",
+                  Detail: "Bad news",
+                  Exp: [
+                    {
+                      id: "2",
+                      Rank: "89",
+                      Status: [
+                        {
+                          Age: "45"
+                        }
+                      ]
+                    },
+                    {
+                      id: "3",
+                      Rank: "88",
+                      Status: ""
+                    }
+                  ]
+                },
+                {
+                  id: '53',
+                  Detail: 'Quite Day',
+                  Exp: ""
+                }
+            ]
+        };
+        xml = $.parseXML(xml);
+        xml = xml.firstElementChild || xml.documentElement;
+        result = Forms._models.Form.xmlToJson(xml, {});
+        assert.deepEqual(record, result);
+        done();
+    });
+
+    suite('subform field name different than subform', function () {
 
       test('form with subform', function (done) {
           var result;
-          var xml = "<Address><Address><id>1</id><Detail>what a whiner</Detail></Address><Address><id>2</id><Detail>great day</Detail></Address><Address><id>3</id><Detail>great food</Detail></Address></Address>";
+          var xml = "<Subform><Address><id>1</id><Detail>what a whiner</Detail></Address><Address><id>2</id><Detail>great day</Detail></Address><Address><id>3</id><Detail>great food</Detail></Address></Subform>";
           var record = {
-            Address: [
+            Subform: [
               {
                 id: "1",
                 Detail: 'what a whiner'
@@ -130,39 +206,46 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
           done();
       });
 
-      test('subform with subform', function (done) {
+      test('subforms with further subform', function (done) {
           var result;
-          var xml = "<Address><Address><id>51</id><Detail>Great work</Detail><Exp><Exp><id>1</id><Rank>45</Rank></Exp></Exp></Address><Address><id>52</id><Detail>Bad news</Detail><Exp><Exp><id>2</id><Rank>89</Rank></Exp><Exp><id>3</id><Rank>88</Rank></Exp></Exp></Address><Address><id>53</id><Detail>Quite Day</Detail><Exp/></Address></Address>";
+          var xml = "<subform><Address><id>51</id><Detail>Great work</Detail><Description><Exp><id>1</id><Rank>45</Rank><Status/></Exp></Description></Address><Address><id>52</id><Detail>Bad news</Detail><Description><Exp><id>2</id><Rank>89</Rank><Status><Status><Age>45</Age></Status></Status></Exp><Exp><id>3</id><Rank>88</Rank><Status/></Exp></Description></Address><Address><id>53</id><Detail>Quite Day</Detail><Description/></Address></subform>";
           var record = {
-            Address: [
+            subform: [
               {
                 id: '51',
                 Detail: 'Great work',
-                Exp: [
+                Description: [
                   {
                     id: '1',
-                    Rank: '45'
+                    Rank: '45',
+                    Status: ''
                   }
                 ]
               },
               {
                 id: '52',
                 Detail: 'Bad news',
-                Exp: [
+                Description: [
                   {
                     id: '2',
-                    Rank: '89'
+                    Rank: '89',
+                    Status: [
+                      {
+                        Age: '45'
+                      }
+                    ]
                   },
                   {
                     id: '3',
-                    Rank: '88'
+                    Rank: '88',
+                    Status: ''
                   }
                 ]
               },
               {
                 id: '53',
                 Detail: 'Quite Day',
-                Exp: ''
+                Description: ''
               }
 
             ]
@@ -174,48 +257,44 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
           done();
       });
 
-      test('subforms with further subforms', function (done) {
+      test('subform with subform', function (done) {
           var result;
-          var xml = "<Address><Address><id>51</id><Detail>Great work</Detail><Exp><Exp><id>1</id><Rank>45</Rank><Status/></Exp></Exp></Address><Address><id>52</id><Detail>Bad news</Detail><Exp><Exp><id>2</id><Rank>89</Rank><Status><Status><Age>45</Age></Status></Status></Exp><Exp><id>3</id><Rank>88</Rank><Status/></Exp></Exp></Address><Address><id>53</id><Detail>Quite Day</Detail><Exp/></Address></Address>";
+          var xml = "<subform><subform1><id>1</id><Age>45</Age><status><subform2><id>1</id><Detail>Great Day</Detail><Rank>4</Rank></subform2><subform2><id>2</id><Detail>welcome </Detail><Rank>3</Rank></subform2></status></subform1><subform1><id>2</id><Age>48</Age><status/></subform1><subform1><id>3</id><Age>56</Age><status><subform2><id>3</id><Detail>standards</Detail><Rank>8</Rank></subform2></status></subform1></subform>";
           var record = {
-              "Address": [
+            subform: [
+              {
+                id: '1',
+                Age: '45',
+                status: [
                   {
-                    id: "51",
-                    Detail: "Great work",
-                    Exp: [
-                      {
-                        id: "1",
-                        Rank: "45",
-                        Status: ""
-                      }
-                    ]
+                    id: '1',
+                    Detail: "Great Day",
+                    Rank: '4'
                   },
                   {
-                    id: "52",
-                    Detail: "Bad news",
-                    Exp: [
-                      {
-                        id: "2",
-                        Rank: "89",
-                        Status: [
-                          {
-                            Age: "45"
-                          }
-                        ]
-                      },
-                      {
-                        id: "3",
-                        Rank: "88",
-                        Status: ""
-                      }
-                    ]
-                  },
-                  {
-                    id: '53',
-                    Detail: 'Quite Day',
-                    Exp: ""
+                    id: '2',
+                    Detail: "welcome ",
+                    Rank: '3'
                   }
-              ]
+                ]
+              },
+              {
+                id: '2',
+                Age: '48',
+                status: ""
+              },
+              {
+                id: '3',
+                Age: '56',
+                status: [
+                  {
+                    id: "3",
+                    Detail: "standards",
+                    Rank: '8'
+                  }
+                ]
+              }
+            ]
           };
           xml = $.parseXML(xml);
           xml = xml.firstElementChild || xml.documentElement;
@@ -224,136 +303,8 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
           done();
       });
 
-      suite('subform field name different than subform', function () {
+    });
 
-        test('form with subform', function (done) {
-            var result;
-            var xml = "<Subform><Address><id>1</id><Detail>what a whiner</Detail></Address><Address><id>2</id><Detail>great day</Detail></Address><Address><id>3</id><Detail>great food</Detail></Address></Subform>";
-            var record = {
-              Subform: [
-                {
-                  id: "1",
-                  Detail: 'what a whiner'
-                },
-                {
-                  id: "2",
-                  Detail: 'great day'
-                },
-                {
-                  id: "3",
-                  Detail: 'great food'
-                }
-
-              ]
-            };
-            xml = $.parseXML(xml);
-            xml = xml.firstElementChild || xml.documentElement;
-            result = Forms._models.Form.xmlToJson(xml, {});
-            assert.deepEqual(record, result);
-            done();
-        });
-
-        test('subforms with further subform', function (done) {
-            var result;
-            var xml = "<subform><Address><id>51</id><Detail>Great work</Detail><Description><Exp><id>1</id><Rank>45</Rank><Status/></Exp></Description></Address><Address><id>52</id><Detail>Bad news</Detail><Description><Exp><id>2</id><Rank>89</Rank><Status><Status><Age>45</Age></Status></Status></Exp><Exp><id>3</id><Rank>88</Rank><Status/></Exp></Description></Address><Address><id>53</id><Detail>Quite Day</Detail><Description/></Address></subform>";
-            var record = {
-              subform: [
-                {
-                  id: '51',
-                  Detail: 'Great work',
-                  Description: [
-                    {
-                      id: '1',
-                      Rank: '45',
-                      Status: ''
-                    }
-                  ]
-                },
-                {
-                  id: '52',
-                  Detail: 'Bad news',
-                  Description: [
-                    {
-                      id: '2',
-                      Rank: '89',
-                      Status: [
-                        {
-                          Age: '45'
-                        }
-                      ]
-                    },
-                    {
-                      id: '3',
-                      Rank: '88',
-                      Status: ''
-                    }
-                  ]
-                },
-                {
-                  id: '53',
-                  Detail: 'Quite Day',
-                  Description: ''
-                }
-
-              ]
-            };
-            xml = $.parseXML(xml);
-            xml = xml.firstElementChild || xml.documentElement;
-            result = Forms._models.Form.xmlToJson(xml, {});
-            assert.deepEqual(record, result);
-            done();
-        });
-
-        test('subform with subform', function (done) {
-            var result;
-            var xml = "<subform><subform1><id>1</id><Age>45</Age><status><subform2><id>1</id><Detail>Great Day</Detail><Rank>4</Rank></subform2><subform2><id>2</id><Detail>welcome </Detail><Rank>3</Rank></subform2></status></subform1><subform1><id>2</id><Age>48</Age><status/></subform1><subform1><id>3</id><Age>56</Age><status><subform2><id>3</id><Detail>standards</Detail><Rank>8</Rank></subform2></status></subform1></subform>";
-            var record = {
-              subform: [
-                {
-                  id: '1',
-                  Age: '45',
-                  status: [
-                    {
-                      id: '1',
-                      Detail: "Great Day",
-                      Rank: '4'
-                    },
-                    {
-                      id: '2',
-                      Detail: "welcome ",
-                      Rank: '3'
-                    }
-                  ]
-                },
-                {
-                  id: '2',
-                  Age: '48',
-                  status: ""
-                },
-                {
-                  id: '3',
-                  Age: '56',
-                  status: [
-                    {
-                      id: "3",
-                      Detail: "standards",
-                      Rank: '8'
-                    }
-                  ]
-                }
-              ]
-            };
-            xml = $.parseXML(xml);
-            xml = xml.firstElementChild || xml.documentElement;
-            result = Forms._models.Form.xmlToJson(xml, {});
-            assert.deepEqual(record, result);
-            done();
-        });
-
-      });
-
-    }); // END: suite('Form', ...)
-
-  }); // END: suite('1', ...)
+  }); // END: suite('Form', ...)
 
 });

--- a/test/16_subform_subform/test.js
+++ b/test/16_subform_subform/test.js
@@ -93,57 +93,11 @@ define(['BlinkForms', 'backbone', 'testUtils', 'BIC'], function (Forms, Backbone
 
   });
 
-  suite('16: subForms render', function () {
-    var $doc = $(document),
-      $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('Test', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-    });
+  suite('16: subForms render', function () {
 
     suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('Test', 'add').then(function (def) {
-          Forms.initialize(def, 'add');
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'Test');
-          assert.equal(form.get('label'), 'Test');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function (done) {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $doc.one('pageinit', function () {
-          done();
-        });
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-
-      });
-
-      testUtils.defineLabelTest();
 
       test('Edit form with subforms', function (done) {
         var form = Forms.current;

--- a/test/16_subform_subform/test.js
+++ b/test/16_subform_subform/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'backbone', 'testUtils', 'BIC'], function (Forms, Backbone, testUtils) {
+define(['BlinkForms', 'backbone', 'testUtils'], function (Forms, Backbone, testUtils) {
   var record$, record, $xml;
 
   suite('getformrecord.xml', function () {

--- a/test/17_image/test.js
+++ b/test/17_image/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   suite('17: Blob fields', function () {
 

--- a/test/17_image/test.js
+++ b/test/17_image/test.js
@@ -1,16 +1,11 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
   suite('17: Blob fields', function () {
-    var $doc = $(document),
-      $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
 
     /**
      * execute once before everything else in this suite
      */
     suiteSetup(function () {
-      $content.empty();
-
       if (!window.navigator.getUserMedia) {
         window.navigator.getUserMedia = {};
       }
@@ -20,47 +15,11 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
       if (!window.URL.createObjectURL) {
         window.URL.createObjectURL = {};
       }
-
-      delete Forms.current;
     });
 
+    testUtils.defineFormLoadSuite('TestForm', 'add');
+
     suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('TestForm', 'add').then(function (def) {
-          Forms.initialize(def, 'add');
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'TestForm');
-          assert.equal(form.get('label'), 'TestForm');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function (done) {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $doc.one('pageinit', function () {
-          done();
-        });
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
 
       test('Render form with data', function (done) {
         var form = Forms.current;

--- a/test/18_calculation/test.js
+++ b/test/18_calculation/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('form1', 'add');
 

--- a/test/18_calculation/test.js
+++ b/test/18_calculation/test.js
@@ -1,52 +1,8 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
+  testUtils.defineFormLoadSuite('form1', 'add');
+
   suite('18: calculations', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
-
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-    });
-
-    suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-    }); // END: suite('Form', ...)
 
     suite('Behaviours: v2 Calculations', function () {
 

--- a/test/18_subform_pages/test.js
+++ b/test/18_subform_pages/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('pageErrors', 'add');
 

--- a/test/18_subform_pages/test.js
+++ b/test/18_subform_pages/test.js
@@ -1,117 +1,46 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
+  testUtils.defineFormLoadSuite('pageErrors', 'add');
+
   suite('18: Subforms with pages', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-    });
+    test('testing subform paging', function (done) {
+      var form = Forms.current,
+        pages = form.attributes.pages,
+        subFormElement,
+        subForms,
+        testData = [
+          { Rank: 1, _action: 'add' },
+          { Rank: 2, _action: 'add' },
+          { Rank: 3, _action: 'add' }
+        ],
+        addPromises = [];
 
-    suite('Form', function () {
+      this.timeout(3000);
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
+      // move to page 1 (page having subform)
+      pages.goto(1);
+      subFormElement = Forms.current.getElement('subform01');
 
-      test('initialise with form.json', function (done) {
-        var form;
+      // switched to adding subforms using .add()
+      // instead of clicking on add button
+      // other tests can confirm add click works alright
+      addPromises.push(subFormElement.add());
+      addPromises.push(subFormElement.add());
+      addPromises.push(subFormElement.add());
 
-        Forms.getDefinition('pageErrors', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'pageErrors');
-          assert.equal(form.get('label'), 'pageErrors');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
+      Promise.all(addPromises).then(function () {
+        subForms = subFormElement.attributes.forms;
+        // adding data to subform elements
+        subForms.at(0).getElement('Rank').val('1');
+        subForms.at(1).getElement('Rank').val('2');
+        subForms.at(2).getElement('Rank').val('3');
 
-      test('render form for jQuery Mobile', function (done) {
-        var form = Forms.current;
+        assert.equal(subForms.at(0).attributes._view.$el.find('input[name="Rank"]').val(), 1);
+        assert.equal(subForms.at(1).attributes._view.$el.find('input[name="Rank"]').val(), 2);
+        assert.equal(subForms.at(2).attributes._view.$el.find('input[name="Rank"]').val(), 3);
 
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-        form.attributes.preloadPromise.then(function () {
-          done();
-        });
-      });
-
-      testUtils.defineLabelTest();
-
-      test('testing subform paging', function (done) {
-        var form = Forms.current,
-          pages = form.attributes.pages,
-          subFormElement,
-          subForms,
-          testData = [
-            { Rank: 1, _action: 'add' },
-            { Rank: 2, _action: 'add' },
-            { Rank: 3, _action: 'add' }
-          ],
-          addPromises = [];
-
-        this.timeout(3000);
-
-        // move to page 1 (page having subform)
-        pages.goto(1);
-        subFormElement = Forms.current.getElement('subform01');
-
-        // switched to adding subforms using .add()
-        // instead of clicking on add button
-        // other tests can confirm add click works alright
-        addPromises.push(subFormElement.add());
-        addPromises.push(subFormElement.add());
-        addPromises.push(subFormElement.add());
-
-        Promise.all(addPromises).then(function () {
-          subForms = subFormElement.attributes.forms;
-          // adding data to subform elements
-          subForms.at(0).getElement('Rank').val('1');
-          subForms.at(1).getElement('Rank').val('2');
-          subForms.at(2).getElement('Rank').val('3');
-
-          assert.equal(subForms.at(0).attributes._view.$el.find('input[name="Rank"]').val(), 1);
-          assert.equal(subForms.at(1).attributes._view.$el.find('input[name="Rank"]').val(), 2);
-          assert.equal(subForms.at(2).attributes._view.$el.find('input[name="Rank"]').val(), 3);
-
-          // check the data of subform element
-          subFormElement.data()
-            .then(function (d) {
-              assert.deepEqual(d, testData, 'subFormElement data');
-              done();
-            });
-        });
-
-      });
-
-      test('Coming back to page with subform', function (done) {
-        var form = Forms.current,
-          pages = form.attributes.pages,
-          subFormElement,
-          testData = [
-            { Rank: 1, _action: 'add' },
-            { Rank: 2, _action: 'add' },
-            { Rank: 3, _action: 'add' }
-          ];
-
-        subFormElement = Forms.current.getElement('subform01');
-        // go to page 2
-        pages.goto(2);
-        // go to page 1
-        pages.goto(1);
-
-        // check the data of subform element again
+        // check the data of subform element
         subFormElement.data()
           .then(function (d) {
             assert.deepEqual(d, testData, 'subFormElement data');
@@ -119,72 +48,96 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
           });
       });
 
-      test('comparing pages sections', function () {
-        var form = Forms.current,
-          pages = form.attributes.pages,
-          section1,
-          section2,
-          section3,
-          newSection;
+    });
 
-        pages.goto(0);
-        section1 = pages.current.attributes._view.el;
+    test('Coming back to page with subform', function (done) {
+      var form = Forms.current,
+        pages = form.attributes.pages,
+        subFormElement,
+        testData = [
+          { Rank: 1, _action: 'add' },
+          { Rank: 2, _action: 'add' },
+          { Rank: 3, _action: 'add' }
+        ];
 
-        pages.goto(1);
-        section2 = pages.current.attributes._view.el;
+      subFormElement = Forms.current.getElement('subform01');
+      // go to page 2
+      pages.goto(2);
+      // go to page 1
+      pages.goto(1);
 
-        pages.goto(2);
-        section3 = pages.current.attributes._view.el;
+      // check the data of subform element again
+      subFormElement.data()
+        .then(function (d) {
+          assert.deepEqual(d, testData, 'subFormElement data');
+          done();
+        });
+    });
 
-        assert.notEqual(section1, section2, 'page1 and page2 section element is same');
-        assert.notEqual(section2, section3, 'page2 and page3 section element is same');
-        assert.notEqual(section3, section1, 'page3 and page1 section element is same');
+    test('comparing pages sections', function () {
+      var form = Forms.current,
+        pages = form.attributes.pages,
+        section1,
+        section2,
+        section3,
+        newSection;
 
-        pages.goto(0);
-        newSection = pages.current.attributes._view.el;
-        assert.notEqual(section1, newSection, 'page1 section changed');
+      pages.goto(0);
+      section1 = pages.current.attributes._view.el;
 
-        pages.goto(1);
-        newSection = pages.current.attributes._view.el;
-        assert.notEqual(section2, newSection, 'page2 section changed');
+      pages.goto(1);
+      section2 = pages.current.attributes._view.el;
 
-        pages.goto(2);
-        newSection = pages.current.attributes._view.el;
-        assert.notEqual(section3, newSection, 'page3 section changed');
+      pages.goto(2);
+      section3 = pages.current.attributes._view.el;
 
-        pages.goto(1);
-        newSection = pages.current.attributes._view.el;
-        assert.notEqual(section2, newSection, 'page2 section changed');
-      });
+      assert.notEqual(section1, section2, 'page1 and page2 section element is same');
+      assert.notEqual(section2, section3, 'page2 and page3 section element is same');
+      assert.notEqual(section3, section1, 'page3 and page1 section element is same');
 
-      test('no crazy nested buttons', function () {
-        var crazy$ = $('div.ui-btn > div.ui-btn > button.ui-btn-hidden');
-        assert.lengthOf(crazy$, 0);
-      });
+      pages.goto(0);
+      newSection = pages.current.attributes._view.el;
+      assert.notEqual(section1, newSection, 'page1 section changed');
 
-      test('no crazy nested inputs', function () {
-        var crazy$ = $('div.ui-input-text > div.ui-input-text > input.ui-input-text');
-        assert.lengthOf(crazy$, 0);
-      });
+      pages.goto(1);
+      newSection = pages.current.attributes._view.el;
+      assert.notEqual(section2, newSection, 'page2 section changed');
 
-      test('all [data-role=fieldcontain] enhanced', function () {
-        var fieldcontain$ = $('[data-role=fieldcontain]');
-        var enhanced$ = $('[data-role=fieldcontain].ui-field-contain');
-        assert.equal(fieldcontain$.length, enhanced$.length);
-      });
+      pages.goto(2);
+      newSection = pages.current.attributes._view.el;
+      assert.notEqual(section3, newSection, 'page3 section changed');
 
-      test('Fields in subforms on other pages can be found and scrolled to', function () {
-        var pages = Forms.current.get('pages');
-        var previousPage;
-        pages.goto(0);
-        previousPage = pages.current.cid;
-        Forms.current.get("_view").goToElement('status');
+      pages.goto(1);
+      newSection = pages.current.attributes._view.el;
+      assert.notEqual(section2, newSection, 'page2 section changed');
+    });
 
-        assert.notEqual(pages.current.cid, previousPage);
-      });
+    test('no crazy nested buttons', function () {
+      var crazy$ = $('div.ui-btn > div.ui-btn > button.ui-btn-hidden');
+      assert.lengthOf(crazy$, 0);
+    });
 
-    }); // END: suite('Form', ...)
+    test('no crazy nested inputs', function () {
+      var crazy$ = $('div.ui-input-text > div.ui-input-text > input.ui-input-text');
+      assert.lengthOf(crazy$, 0);
+    });
 
-  }); // END: suite('1', ...)
+    test('all [data-role=fieldcontain] enhanced', function () {
+      var fieldcontain$ = $('[data-role=fieldcontain]');
+      var enhanced$ = $('[data-role=fieldcontain].ui-field-contain');
+      assert.equal(fieldcontain$.length, enhanced$.length);
+    });
+
+    test('Fields in subforms on other pages can be found and scrolled to', function () {
+      var pages = Forms.current.get('pages');
+      var previousPage;
+      pages.goto(0);
+      previousPage = pages.current.cid;
+      Forms.current.get("_view").goToElement('status');
+
+      assert.notEqual(pages.current.cid, previousPage);
+    });
+
+  }); // END: suite('Form', ...)
 
 });

--- a/test/1_date_time/test.js
+++ b/test/1_date_time/test.js
@@ -90,229 +90,185 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
     });
   }
 
-  suite('1: date/time', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('form1', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  suite('1: date/time', function () {
+
+    test('all now and now_plus models have non-empty values', function () {
+      Forms.current.get('elements').forEach(function (el) {
+        var defaultValue = el.get('defaultValue');
+        if (defaultValue && defaultValue.indexOf('now') !== -1) {
+          assert.ok(el.val(), el.get('name') + ': non-empty');
+        }
+      });
     });
 
-    suite('Form', function () {
+    test('all models with no default have non-empty values', function () {
+      Forms.current.get('elements').forEach(function (el) {
+        var defaultValue = el.get('defaultValue');
+        if (!defaultValue) {
+          assert.notOk(el.val(), el.get('name') + ': empty');
+        }
+      });
+    });
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
+    defineModelToViewTests();
+    defineViewToModelTests();
+
+    test('use datetime field - avoid undefined', function () {
+      var form = Forms.current,
+        element = form.getElement('datetimenonative'),
+        $fieldset = element.attributes._view.$el,
+        date = $fieldset.find('input[name="datetimenonative_date"]'),
+        time = $fieldset.find('input[name="datetimenonative_time"]');
+
+      date.val("2014-02-01").change();
+      assert.equal(element.val(), "2014-02-01T00:00");
+
+      date.val("").change();
+      time.val("").change();
+      time.val("10:11").change();
+      assert.equal(element.val(), "0000-00-00T10:11");
+    });
+
+    test('use datetime field - organise elements properly on screen', function () {
+      var form = Forms.current,
+        element = form.getElement('datetimenonative'),
+        $fieldset = element.attributes._view.$el.children(),
+        elementsInOrder = [
+          'LABEL',
+          'DIV',
+          'LABEL',
+          'DIV'
+        ];
+
+      elementsInOrder.forEach(function (v, k) {
+        assert.equal($($fieldset[k]).prop('tagName'), v);
+      });
+    });
+
+    test('use native picker defaults to native picker', function () {
+      var form = Forms.current,
+        element,
+        $fieldset;
+      nativedate.forEach(function (fld) {
+        element = form.getElement(fld);
+        $fieldset = element.attributes._view.$el;
+        assert.equal($fieldset.find('input[name="' + fld + '_date"]').attr('type'), 'date');
+      });
+      nativetime.forEach(function (fld) {
+        element = form.getElement(fld);
+        $fieldset = element.attributes._view.$el;
+        assert.equal($fieldset.find('input[name="' + fld + '_time"]').attr('type'), 'time');
+      });
+    });
+
+    ['_date', '_time'].forEach(function (subtype) {
+      var elements = subtype === '_date' ? pickadate : pickatime;
+
+      elements.forEach(function (fld) {
+
+        test('pickerElements outside page: ' + fld, function (done) {
+          var form = Forms.current;
+
+          this.timeout(3e3);
+
+          setTimeout(function () {
+
+            var element = form.getElement(fld);
+            var $fieldset = element.attributes._view.$el;
+            var $input = $fieldset.find('input[name="' + fld + subtype + '"]');
+            var $root = $("#" + $input.attr('id') + "_root.picker");
+
+            assert.equal($input.hasClass('picker__input'), true);
+            assert.equal($root.length, 1);
+            assert.equal($root.parent().hasClass('ui-body-c'), true);
+
+            assert(!!element);
+
+            done();
+          }, 300);
+        });
+
       });
 
-      test('initialise with form.json', function (done) {
-        var form;
+    });
 
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
+    suite('readonly, hidden', function () {
+      var readonly = [
+          'dateTimeRonlyNone',
+          'dateTimeRonlyNow',
+          'dateTimeRonlyNowP',
+          'dateTimeRonlyNowPM'
+        ],
+        hidden = [
+          'dateTimeHiddenNone',
+          'dateTimeHiddenNow',
+          'dateTimeHiddenNowP',
+          'dateTimeHddenNowPM'
+        ];
+
+      test('check if readonly fields are actually readonly', function () {
+        var form = Forms.current,
+          element,
+          $fieldset;
+
+        readonly.forEach(function (fld) {
+          element = form.getElement(fld);
+          $fieldset = element.attributes._view.$el;
+          // should not contain any input fields
+          assert.equal($fieldset.find("input").length, 0);
+          assert.equal(element.attributes.picker, "shown");
+          assert(element.attributes.readonly);
         });
       });
 
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-      test('all now and now_plus models have non-empty values', function () {
-        Forms.current.get('elements').forEach(function (el) {
-          var defaultValue = el.get('defaultValue');
-          if (defaultValue && defaultValue.indexOf('now') !== -1) {
-            assert.ok(el.val(), el.get('name') + ': non-empty');
-          }
-        });
-      });
-
-      test('all models with no default have non-empty values', function () {
-        Forms.current.get('elements').forEach(function (el) {
-          var defaultValue = el.get('defaultValue');
-          if (!defaultValue) {
-            assert.notOk(el.val(), el.get('name') + ': empty');
-          }
+      test('check if hidden fields are actually hidden', function () {
+        var form = Forms.current,
+          element,
+          $fieldset;
+        hidden.forEach(function (fld) {
+          element = form.getElement(fld);
+          $fieldset = element.attributes._view.$el;
+          // should have display: none set in stylesheet
+          assert.equal($fieldset.css('display'), 'none');
+          assert.equal(element.attributes.picker, "hidden");
+          assert(element.attributes.hidden);
         });
       });
 
       defineModelToViewTests();
       defineViewToModelTests();
+    });
 
-      test('use datetime field - avoid undefined', function () {
-        var form = Forms.current,
-          element = form.getElement('datetimenonative'),
-          $fieldset = element.attributes._view.$el,
-          date = $fieldset.find('input[name="datetimenonative_date"]'),
-          time = $fieldset.find('input[name="datetimenonative_time"]');
+    suite('native, date assignment', function () {
+      var native = [
+        // 'dateTimeNativePickerNone',
+        'dateTimeNativePickerNow',
+        'dateTimeNativePickerNowP',
+        'dateTimeNativePckerNowPM'
+      ];
 
-        date.val("2014-02-01").change();
-        assert.equal(element.val(), "2014-02-01T00:00");
-
-        date.val("").change();
-        time.val("").change();
-        time.val("10:11").change();
-        assert.equal(element.val(), "0000-00-00T10:11");
-      });
-
-      test('use datetime field - organise elements properly on screen', function () {
-        var form = Forms.current,
-          element = form.getElement('datetimenonative'),
-          $fieldset = element.attributes._view.$el.children(),
-          elementsInOrder = [
-            'LABEL',
-            'DIV',
-            'LABEL',
-            'DIV'
-          ];
-
-        elementsInOrder.forEach(function (v, k) {
-          assert.equal($($fieldset[k]).prop('tagName'), v);
-        });
-      });
-
-      test('use native picker defaults to native picker', function () {
+      test('check if date fields have correct values', function () {
         var form = Forms.current,
           element,
-          $fieldset;
-        nativedate.forEach(function (fld) {
+          $fieldset,
+          $input;
+
+        native.forEach(function (fld) {
           element = form.getElement(fld);
           $fieldset = element.attributes._view.$el;
-          assert.equal($fieldset.find('input[name="' + fld + '_date"]').attr('type'), 'date');
-        });
-        nativetime.forEach(function (fld) {
-          element = form.getElement(fld);
-          $fieldset = element.attributes._view.$el;
-          assert.equal($fieldset.find('input[name="' + fld + '_time"]').attr('type'), 'time');
+          // should contain date field
+          $input = $fieldset.find("input[type='date']");
+          assert.equal($input.length, 1);
+          assert($input.val(), "no value assigned to $input");
         });
       });
 
-      ['_date', '_time'].forEach(function (subtype) {
-        var elements = subtype === '_date' ? pickadate : pickatime;
+      defineModelToViewTests();
+      defineViewToModelTests();
+    });
 
-        elements.forEach(function (fld) {
-
-          test('pickerElements outside page: ' + fld, function (done) {
-            var form = Forms.current;
-
-            this.timeout(3e3);
-
-            setTimeout(function () {
-
-              var element = form.getElement(fld);
-              var $fieldset = element.attributes._view.$el;
-              var $input = $fieldset.find('input[name="' + fld + subtype + '"]');
-              var $root = $("#" + $input.attr('id') + "_root.picker");
-
-              assert.equal($input.hasClass('picker__input'), true);
-              assert.equal($root.length, 1);
-              assert.equal($root.parent().hasClass('ui-body-c'), true);
-
-              assert(!!element);
-
-              done();
-            }, 300);
-          });
-
-        });
-
-      });
-
-      suite('readonly, hidden', function () {
-        var readonly = [
-            'dateTimeRonlyNone',
-            'dateTimeRonlyNow',
-            'dateTimeRonlyNowP',
-            'dateTimeRonlyNowPM'
-          ],
-          hidden = [
-            'dateTimeHiddenNone',
-            'dateTimeHiddenNow',
-            'dateTimeHiddenNowP',
-            'dateTimeHddenNowPM'
-          ];
-
-        test('check if readonly fields are actually readonly', function () {
-          var form = Forms.current,
-            element,
-            $fieldset;
-
-          readonly.forEach(function (fld) {
-            element = form.getElement(fld);
-            $fieldset = element.attributes._view.$el;
-            // should not contain any input fields
-            assert.equal($fieldset.find("input").length, 0);
-            assert.equal(element.attributes.picker, "shown");
-            assert(element.attributes.readonly);
-          });
-        });
-
-        test('check if hidden fields are actually hidden', function () {
-          var form = Forms.current,
-            element,
-            $fieldset;
-          hidden.forEach(function (fld) {
-            element = form.getElement(fld);
-            $fieldset = element.attributes._view.$el;
-            // should have display: none set in stylesheet
-            assert.equal($fieldset.css('display'), 'none');
-            assert.equal(element.attributes.picker, "hidden");
-            assert(element.attributes.hidden);
-          });
-        });
-
-        defineModelToViewTests();
-        defineViewToModelTests();
-      });
-
-      suite('native, date assignment', function () {
-        var native = [
-          // 'dateTimeNativePickerNone',
-          'dateTimeNativePickerNow',
-          'dateTimeNativePickerNowP',
-          'dateTimeNativePckerNowPM'
-        ];
-
-        test('check if date fields have correct values', function () {
-          var form = Forms.current,
-            element,
-            $fieldset,
-            $input;
-
-          native.forEach(function (fld) {
-            element = form.getElement(fld);
-            $fieldset = element.attributes._view.$el;
-            // should contain date field
-            $input = $fieldset.find("input[type='date']");
-            assert.equal($input.length, 1);
-            assert($input.val(), "no value assigned to $input");
-          });
-        });
-
-        defineModelToViewTests();
-        defineViewToModelTests();
-      });
-
-    }); // END: suite('Form', ...)
-
-  }); // END: suite('1', ...)
+  }); // END: suite('Form', ...)
 
 });

--- a/test/1_date_time/test.js
+++ b/test/1_date_time/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   var nativedate = [
     'date',

--- a/test/20_2013W31v/test.js
+++ b/test/20_2013W31v/test.js
@@ -1,52 +1,12 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
   'use strict';
 
-  suite('2: options', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('test_form', 'add');
+  // just loading this legacy definition is the entire purpose of this test
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-    });
+  suite('20: 2013W31.v', function () {
 
-    suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('test_form', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'test_form');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-    }); // END: suite('Form', ...)
+    test('');
 
   }); // END: suite('1', ...)
 

--- a/test/20_2013W31v/test.js
+++ b/test/20_2013W31v/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['testUtils'], function (testUtils) {
   'use strict';
 
   testUtils.defineFormLoadSuite('test_form', 'add');

--- a/test/21-readonly_view/test.js
+++ b/test/21-readonly_view/test.js
@@ -1,106 +1,57 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
-  suite('21: Readonly View ', function () {
-    var $doc = $(document),
-      $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('TestForm', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  suite('21: Readonly View', function () {
+
+    test('Render form with data', function (done) {
+      var form = Forms.current;
+      $.ajax({
+        type: "GET",
+        url: "getformrecord.xml",
+        dataType: "xml"}).then(
+        function (data) {
+          var record = {}, node, nodes;
+          nodes = data.evaluate('//' + form.attributes.name, data);
+          node = nodes.iterateNext();
+          _.each(node.children, function (key) {
+            record[key.nodeName] = key.innerHTML;
+          });
+          form.setRecord(record).then(function () {
+            form.data().then(function (formdata) {
+              var keys = _.keys(record);
+              _.each(keys, function (k) {
+                assert.ok(formdata[k], k + " does not exist");
+              });
+              done();
+            }, function () {
+              assert(false, "failed to set record");
+              done();
+            });
+          });
+        }
+     );
     });
 
-    suite('Form', function () {
+    test('no input/button elements present', function (done) {
+      var form = Forms.current,
+        element,
+        view,
+        figure,
+        elements = ['Photo', 'location', 'draw', 'Rank', 'Details'];
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('TestForm', 'add').then(function (def) {
-          Forms.initialize(def, 'add');
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'TestForm');
-          assert.equal(form.get('label'), 'TestForm');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
+        _.each(elements, function (name) {
+          element = form.getElement(name);
+          view = element.attributes._view.$el;
+          figure = view.children('figure');
+          assert.lengthOf(figure.children('image'), 0);
+          assert.lengthOf(view.children('button'), 0);
+          assert.lengthOf(view.children('a'), 0);
+          assert.lengthOf(view.children('input'), 0);
         });
-      });
+      done();
+    });
 
-      test('render form for jQuery Mobile', function (done) {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $doc.one('pageinit', function () {
-          done();
-        });
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-      test('Render form with data', function (done) {
-        var form = Forms.current;
-        $.ajax({
-          type: "GET",
-          url: "getformrecord.xml",
-          dataType: "xml"}).then(
-          function (data) {
-            var record = {}, node, nodes;
-            nodes = data.evaluate('//' + form.attributes.name, data);
-            node = nodes.iterateNext();
-            _.each(node.children, function (key) {
-              record[key.nodeName] = key.innerHTML;
-            });
-            form.setRecord(record).then(function () {
-              form.data().then(function (formdata) {
-                var keys = _.keys(record);
-                _.each(keys, function (k) {
-                  assert.ok(formdata[k], k + " does not exist");
-                });
-                done();
-              }, function () {
-                assert(false, "failed to set record");
-                done();
-              });
-            });
-          }
-       );
-      });
-
-      test('no input/button elements present', function (done) {
-        var form = Forms.current,
-          element,
-          view,
-          figure,
-          elements = ['Photo', 'location', 'draw', 'Rank', 'Details'];
-
-          _.each(elements, function (name) {
-            element = form.getElement(name);
-            view = element.attributes._view.$el;
-            figure = view.children('figure');
-            assert.lengthOf(figure.children('image'), 0);
-            assert.lengthOf(view.children('button'), 0);
-            assert.lengthOf(view.children('a'), 0);
-            assert.lengthOf(view.children('input'), 0);
-          });
-        done();
-      });
-
-    }); // END: suite('Form', ...)
-
-  }); // END: suite('1', ...)
+  }); // END: suite('Form', ...)
 
 });

--- a/test/21-readonly_view/test.js
+++ b/test/21-readonly_view/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('TestForm', 'add');
 

--- a/test/22_CustomCSS/test.js
+++ b/test/22_CustomCSS/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('TestForm', 'add');
 

--- a/test/22_CustomCSS/test.js
+++ b/test/22_CustomCSS/test.js
@@ -1,102 +1,53 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
-  suite('22: Custom CSS', function () {
-    var $doc = $(document),
-      $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('TestForm', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  suite('22: Custom CSS', function () {
+
+    test('Render form with data', function (done) {
+      var form = Forms.current;
+      $.ajax({
+        type: "GET",
+        url: "getformrecord.xml",
+        dataType: "xml"}).then(
+        function (data) {
+          var record = {}, node, nodes;
+          nodes = data.evaluate('//' + form.attributes.name, data);
+          node = nodes.iterateNext();
+          _.each(node.children, function (key) {
+            record[key.nodeName] = key.innerHTML;
+          });
+          form.setRecord(record).then(function () {
+            form.data().then(function (formdata) {
+              var keys = _.keys(record);
+              _.each(keys, function (k) {
+                assert.ok(formdata[k], k + " does not exist");
+              });
+              done();
+            }, function () {
+              assert(false, "failed to set record");
+              done();
+            });
+          });
+        }
+     );
     });
 
-    suite('Form', function () {
+    test('Applying custom CSS using element name/type', function (done) {
+      var form = Forms.current,
+        hiddenElements = form.$form.find('div:hidden'),
+        elements = ['Photo', 'Photo1', 'Photo2', 'location'],
+        name;
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('TestForm', 'add').then(function (def) {
-          Forms.initialize(def, 'add');
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'TestForm');
-          assert.equal(form.get('label'), 'TestForm');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function (done) {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $doc.one('pageinit', function () {
-          done();
-        });
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-      test('Render form with data', function (done) {
-        var form = Forms.current;
-        $.ajax({
-          type: "GET",
-          url: "getformrecord.xml",
-          dataType: "xml"}).then(
-          function (data) {
-            var record = {}, node, nodes;
-            nodes = data.evaluate('//' + form.attributes.name, data);
-            node = nodes.iterateNext();
-            _.each(node.children, function (key) {
-              record[key.nodeName] = key.innerHTML;
-            });
-            form.setRecord(record).then(function () {
-              form.data().then(function (formdata) {
-                var keys = _.keys(record);
-                _.each(keys, function (k) {
-                  assert.ok(formdata[k], k + " does not exist");
-                });
-                done();
-              }, function () {
-                assert(false, "failed to set record");
-                done();
-              });
-            });
+        _.each(hiddenElements, function (element) {
+          name = $(element).data('name');
+          if (name) {
+            assert.isTrue(_.contains(elements, name));
           }
-       );
-      });
+        });
+      done();
+    });
 
-      test('Applying custom CSS using element name/type', function (done) {
-        var form = Forms.current,
-          hiddenElements = form.$form.find('div:hidden'),
-          elements = ['Photo', 'Photo1', 'Photo2', 'location'],
-          name;
-
-          _.each(hiddenElements, function (element) {
-            name = $(element).data('name');
-            if (name) {
-              assert.isTrue(_.contains(elements, name));
-            }
-          });
-        done();
-      });
-
-    }); // END: suite('Form', ...)
-
-  }); // END: suite('1', ...)
+  }); // END: suite('Form', ...)
 
 });

--- a/test/23_1_location_native/test.js
+++ b/test/23_1_location_native/test.js
@@ -1,7 +1,7 @@
 
 /*global assert, sinon*/ // chai
 
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   window.MSApp = {};
 

--- a/test/23_1_location_native/test.js
+++ b/test/23_1_location_native/test.js
@@ -3,337 +3,288 @@
 
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
+  window.MSApp = {};
+
+  if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
+    return;
+  }
+
+  testUtils.defineFormLoadSuite('TestForm', 'add');
+
   suite('23_1: Location Native field', function () {
-    var $doc = $(document),
-      $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
 
-    window.MSApp = {};
+    test('Render form with data', function (done) {
+      var form = Forms.current;
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+      $.ajax({
+        type: "GET",
+        url: "getformrecord.xml",
+        dataType: "xml"}).then(
+        function (data) {
+          var record = {}, node, nodes;
+          nodes = data.evaluate('//' + form.attributes.name, data);
+          node = nodes.iterateNext();
+          _.each(node.children, function (key) {
+            record[key.nodeName] = key.innerHTML;
+          });
+          form.setRecord(record).then(function () {
+            form.data().then(function (formdata) {
+              var keys = ['id', 'location1', 'location2', '_action'];
+              _.each(keys, function (k) {
+                assert.ok(formdata[k], k + " does not exist");
+              });
+              done();
+            }, function () {
+              assert(false, "failed to set record");
+              done();
+            });
+          });
+        }
+     );
     });
 
-    suite('Form', function () {
+    test('LOCATE button - success callback + no location', function (done) {
+      var element = Forms.current.getElement('location2'),
+        $view = element.attributes._view.$el,
+        $locate = $view.find('.ui-btn').children('button').first(),
+        spy, spyStatic;
 
-      if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
-        return;
-      }
+      window.navigator.map = {
+        confirmLocation: function (onSuccess, onError, options) {
+          assert.isFunction(onSuccess);
+          assert.isFunction(onError);
+          assert.ok(options.latitude);
+          assert.ok(options.longitude);
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
+          onSuccess(null);
 
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('TestForm', 'add').then(function (def) {
-          Forms.initialize(def, 'add');
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'TestForm');
-          assert.equal(form.get('label'), 'TestForm');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function (done) {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $doc.one('pageinit', function () {
-          done();
-        });
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-      test('Render form with data', function (done) {
-        var form = Forms.current;
-
-        $.ajax({
-          type: "GET",
-          url: "getformrecord.xml",
-          dataType: "xml"}).then(
-          function (data) {
-            var record = {}, node, nodes;
-            nodes = data.evaluate('//' + form.attributes.name, data);
-            node = nodes.iterateNext();
-            _.each(node.children, function (key) {
-              record[key.nodeName] = key.innerHTML;
-            });
-            form.setRecord(record).then(function () {
-              form.data().then(function (formdata) {
-                var keys = ['id', 'location1', 'location2', '_action'];
-                _.each(keys, function (k) {
-                  assert.ok(formdata[k], k + " does not exist");
-                });
-                done();
-              }, function () {
-                assert(false, "failed to set record");
-                done();
-              });
-            });
-          }
-       );
-      });
-
-      test('LOCATE button - success callback + no location', function (done) {
-        var element = Forms.current.getElement('location2'),
-          $view = element.attributes._view.$el,
-          $locate = $view.find('.ui-btn').children('button').first(),
-          spy, spyStatic;
-
-        window.navigator.map = {
-          confirmLocation: function (onSuccess, onError, options) {
-            assert.isFunction(onSuccess);
-            assert.isFunction(onError);
-            assert.ok(options.latitude);
-            assert.ok(options.longitude);
-
-            onSuccess(null);
-
-            element.attributes._view.on('confirmLocation', function (loc) {
-              assert.equal(loc, null);
-              element.attributes._view.off('confirmLocation');
-              done();
-            });
-          },
-          getStaticMap: function (onSuccess, onError) {
-            assert.isFunction(onSuccess);
-            assert.isFunction(onError);
-          }
-        };
-
-        spy = sinon.spy(window.navigator.map, "confirmLocation");
-        spyStatic = sinon.spy(window.navigator.map, "getStaticMap");
-
-        element.once('change:value', function () {
-          assert.equal(spyStatic.callCount, 0);
-        });
-
-        assert.equal(spy.callCount, 0);
-
-        $locate.trigger('click');
-
-        assert.equal(spy.callCount, 1);
-
-      });
-
-      test('LOCATE button - success callback + location', function (done) {
-        var element = Forms.current.getElement('location2'),
-          $view = element.attributes._view.$el,
-          $locate = $view.find('.ui-btn').children('button').first(),
-          spy, spyStatic;
-
-        window.navigator.map = {
-          confirmLocation: function (onSuccess, onError, options) {
-            var sampleLocation = {"latitude": -33.867487, "longitude": 151.20699, "accuracy": 25000};
-            assert.isFunction(onSuccess);
-            assert.isFunction(onError);
-            assert.ok(options.latitude);
-            assert.ok(options.longitude);
-
-            onSuccess(sampleLocation);
-
-            setTimeout(function () {
-              assert.deepEqual(element.get('value'), sampleLocation);
-              done();
-            }, 1);
-          },
-          getStaticMap: function (onSuccess, onError) {
-            assert.isFunction(onSuccess);
-            assert.isFunction(onError);
-          }
-        };
-
-        spy = sinon.spy(window.navigator.map, "confirmLocation");
-        spyStatic = sinon.spy(window.navigator.map, "getStaticMap");
-
-        element.once('change:value', function () {
-          assert.equal(spyStatic.callCount, 1);
-        });
-
-        assert.equal(spy.callCount, 0);
-
-        $locate.trigger('click');
-
-        assert.equal(spy.callCount, 1);
-
-      });
-
-      test('LOCATE button - error callback', function (done) {
-        var element = Forms.current.getElement('location2'),
-          $view = element.attributes._view.$el,
-          $locate = $view.find('.ui-btn').children('button').first(),
-          spy, spyStatic;
-
-        window.navigator.map = {
-          confirmLocation: function (onSuccess, onError, options) {
-            var spy2 = sinon.spy(window.console, "error");
-            assert.isFunction(onSuccess);
-            assert.isFunction(onError);
-            assert.ok(options.latitude);
-            assert.ok(options.longitude);
-
-            assert(!onError("test error"));
-
-            setTimeout(function () {
-              assert.equal(spy2.callCount, 1);
-              window.console.error.restore();
-              done();
-            }, 1);
-          },
-          getStaticMap: function (onSuccess, onError) {
-            assert.isFunction(onSuccess);
-            assert.isFunction(onError);
-          }
-        };
-
-        spy = sinon.spy(window.navigator.map, "confirmLocation");
-        spyStatic = sinon.spy(window.navigator.map, "getStaticMap");
-
-        element.once('change:value', function () {
-          assert.equal(spyStatic.callCount, 0);
-        });
-
-        assert.equal(spy.callCount, 0);
-
-        $locate.trigger('click');
-
-        assert.equal(spy.callCount, 1);
-
-      });
-
-      test('CLEAR button works as expected', function (done) {
-        var element = Forms.current.getElement('location2'),
-          $view = element.attributes._view.$el,
-          $clear = $view.find('.ui-btn').children('button').last(),
-          value;
-
-        $clear.trigger('click');
-
-        setTimeout(function () {
-            value = element.get('value');
-            assert.notOk(value, "value still exists");
+          element.attributes._view.on('confirmLocation', function (loc) {
+            assert.equal(loc, null);
+            element.attributes._view.off('confirmLocation');
             done();
-        }, 0);
+          });
+        },
+        getStaticMap: function (onSuccess, onError) {
+          assert.isFunction(onSuccess);
+          assert.isFunction(onError);
+        }
+      };
+
+      spy = sinon.spy(window.navigator.map, "confirmLocation");
+      spyStatic = sinon.spy(window.navigator.map, "getStaticMap");
+
+      element.once('change:value', function () {
+        assert.equal(spyStatic.callCount, 0);
       });
 
-      test('LOCATE button - success callback + location + getStaticImage > success', function (done) {
-        var element = Forms.current.getElement('location2'),
-          $view = element.attributes._view.$el,
-          $locate = $view.find('.ui-btn').children('button').first(),
-          spy, spyStatic, sampleImage;
+      assert.equal(spy.callCount, 0);
 
-        sampleImage = "data:image/jpeg;base64,blah";
+      $locate.trigger('click');
 
-        window.navigator.map = {
-          confirmLocation: function (onSuccess, onError, options) {
-            var sampleLocation = {
-              "latitude": -33.867487,
-              "longitude": 151.20699,
-              "accuracy": 25000
-            };
-            assert.isFunction(onSuccess);
-            assert.isFunction(onError);
-            assert.ok(options.latitude);
-            assert.ok(options.longitude);
+      assert.equal(spy.callCount, 1);
 
-            onSuccess(sampleLocation);
-          },
-          getStaticMap: function (onSuccess, onError) {
-            assert.isFunction(onSuccess);
-            assert.isFunction(onError);
+    });
 
-            onSuccess(sampleImage);
-          }
-        };
+    test('LOCATE button - success callback + location', function (done) {
+      var element = Forms.current.getElement('location2'),
+        $view = element.attributes._view.$el,
+        $locate = $view.find('.ui-btn').children('button').first(),
+        spy, spyStatic;
 
-        spy = sinon.spy(window.navigator.map, "confirmLocation");
-        spyStatic = sinon.spy(window.navigator.map, "getStaticMap");
+      window.navigator.map = {
+        confirmLocation: function (onSuccess, onError, options) {
+          var sampleLocation = {"latitude": -33.867487, "longitude": 151.20699, "accuracy": 25000};
+          assert.isFunction(onSuccess);
+          assert.isFunction(onError);
+          assert.ok(options.latitude);
+          assert.ok(options.longitude);
 
-        element.once('change:value', function () {
-          var $img;
-          assert.equal(spy.callCount, 1);
-          assert.equal(spyStatic.callCount, 1);
-          // there will be atleast one image and src would be the content sent by onSuccess
-          $img = element.get('_view').$el.find('img');
-          assert.equal($img.length, 1, "image not found");
-          assert.equal(element.get('_view').$el.find('img').attr('src'), sampleImage, "invalid image src");
+          onSuccess(sampleLocation);
 
+          setTimeout(function () {
+            assert.deepEqual(element.get('value'), sampleLocation);
+            done();
+          }, 1);
+        },
+        getStaticMap: function (onSuccess, onError) {
+          assert.isFunction(onSuccess);
+          assert.isFunction(onError);
+        }
+      };
+
+      spy = sinon.spy(window.navigator.map, "confirmLocation");
+      spyStatic = sinon.spy(window.navigator.map, "getStaticMap");
+
+      element.once('change:value', function () {
+        assert.equal(spyStatic.callCount, 1);
+      });
+
+      assert.equal(spy.callCount, 0);
+
+      $locate.trigger('click');
+
+      assert.equal(spy.callCount, 1);
+
+    });
+
+    test('LOCATE button - error callback', function (done) {
+      var element = Forms.current.getElement('location2'),
+        $view = element.attributes._view.$el,
+        $locate = $view.find('.ui-btn').children('button').first(),
+        spy, spyStatic;
+
+      window.navigator.map = {
+        confirmLocation: function (onSuccess, onError, options) {
+          var spy2 = sinon.spy(window.console, "error");
+          assert.isFunction(onSuccess);
+          assert.isFunction(onError);
+          assert.ok(options.latitude);
+          assert.ok(options.longitude);
+
+          assert(!onError("test error"));
+
+          setTimeout(function () {
+            assert.equal(spy2.callCount, 1);
+            window.console.error.restore();
+            done();
+          }, 1);
+        },
+        getStaticMap: function (onSuccess, onError) {
+          assert.isFunction(onSuccess);
+          assert.isFunction(onError);
+        }
+      };
+
+      spy = sinon.spy(window.navigator.map, "confirmLocation");
+      spyStatic = sinon.spy(window.navigator.map, "getStaticMap");
+
+      element.once('change:value', function () {
+        assert.equal(spyStatic.callCount, 0);
+      });
+
+      assert.equal(spy.callCount, 0);
+
+      $locate.trigger('click');
+
+      assert.equal(spy.callCount, 1);
+
+    });
+
+    test('CLEAR button works as expected', function (done) {
+      var element = Forms.current.getElement('location2'),
+        $view = element.attributes._view.$el,
+        $clear = $view.find('.ui-btn').children('button').last(),
+        value;
+
+      $clear.trigger('click');
+
+      setTimeout(function () {
+          value = element.get('value');
+          assert.notOk(value, "value still exists");
           done();
-        });
+      }, 0);
+    });
 
-        assert.equal(spy.callCount, 0);
+    test('LOCATE button - success callback + location + getStaticImage > success', function (done) {
+      var element = Forms.current.getElement('location2'),
+        $view = element.attributes._view.$el,
+        $locate = $view.find('.ui-btn').children('button').first(),
+        spy, spyStatic, sampleImage;
 
-        $locate.trigger('click');
+      sampleImage = "data:image/jpeg;base64,blah";
+
+      window.navigator.map = {
+        confirmLocation: function (onSuccess, onError, options) {
+          var sampleLocation = {
+            "latitude": -33.867487,
+            "longitude": 151.20699,
+            "accuracy": 25000
+          };
+          assert.isFunction(onSuccess);
+          assert.isFunction(onError);
+          assert.ok(options.latitude);
+          assert.ok(options.longitude);
+
+          onSuccess(sampleLocation);
+        },
+        getStaticMap: function (onSuccess, onError) {
+          assert.isFunction(onSuccess);
+          assert.isFunction(onError);
+
+          onSuccess(sampleImage);
+        }
+      };
+
+      spy = sinon.spy(window.navigator.map, "confirmLocation");
+      spyStatic = sinon.spy(window.navigator.map, "getStaticMap");
+
+      element.once('change:value', function () {
+        var $img;
+        assert.equal(spy.callCount, 1);
+        assert.equal(spyStatic.callCount, 1);
+        // there will be atleast one image and src would be the content sent by onSuccess
+        $img = element.get('_view').$el.find('img');
+        assert.equal($img.length, 1, "image not found");
+        assert.equal(element.get('_view').$el.find('img').attr('src'), sampleImage, "invalid image src");
+
+        done();
       });
 
-      test('LOCATE button - success callback + location + getStaticImage > error', function (done) {
-        var element = Forms.current.getElement('location2'),
-          $view = element.attributes._view.$el,
-          $locate = $view.find('.ui-btn').children('button').first(),
-          spy, spyStatic, spyError;
+      assert.equal(spy.callCount, 0);
 
-        window.navigator.map = {
-          confirmLocation: function (onSuccess, onError, options) {
-            var sampleLocation = {
-              "latitude": -33.861234,
-              "longitude": 151.20699,
-              "accuracy": 25000
-            };
-            assert.isFunction(onSuccess);
-            assert.isFunction(onError);
-            assert.ok(options.latitude);
-            assert.ok(options.longitude);
+      $locate.trigger('click');
+    });
 
-            onSuccess(sampleLocation);
-          },
-          getStaticMap: function (onSuccess, onError) {
-            assert.isFunction(onSuccess);
-            assert.isFunction(onError);
+    test('LOCATE button - success callback + location + getStaticImage > error', function (done) {
+      var element = Forms.current.getElement('location2'),
+        $view = element.attributes._view.$el,
+        $locate = $view.find('.ui-btn').children('button').first(),
+        spy, spyStatic, spyError;
 
-            onError("map cannot be displayed");
-          }
-        };
+      window.navigator.map = {
+        confirmLocation: function (onSuccess, onError, options) {
+          var sampleLocation = {
+            "latitude": -33.861234,
+            "longitude": 151.20699,
+            "accuracy": 25000
+          };
+          assert.isFunction(onSuccess);
+          assert.isFunction(onError);
+          assert.ok(options.latitude);
+          assert.ok(options.longitude);
 
-        spy = sinon.spy(window.navigator.map, "confirmLocation");
-        spyStatic = sinon.spy(window.navigator.map, "getStaticMap");
-        spyError = sinon.spy(window.console, "error");
+          onSuccess(sampleLocation);
+        },
+        getStaticMap: function (onSuccess, onError) {
+          assert.isFunction(onSuccess);
+          assert.isFunction(onError);
 
-        element.once('change:value', function () {
-          var $img;
-          assert.equal(spy.callCount, 1);
-          assert.equal(spyStatic.callCount, 1);
-          assert.equal(spyError.callCount, 1);
-          // there won't be any image, because of error call
-          $img = element.get('_view').$el.find('img');
-          assert.equal($img.length, 0, "image not found");
-          window.console.error.restore();
+          onError("map cannot be displayed");
+        }
+      };
 
-          done();
-        });
+      spy = sinon.spy(window.navigator.map, "confirmLocation");
+      spyStatic = sinon.spy(window.navigator.map, "getStaticMap");
+      spyError = sinon.spy(window.console, "error");
 
-        assert.equal(spy.callCount, 0);
+      element.once('change:value', function () {
+        var $img;
+        assert.equal(spy.callCount, 1);
+        assert.equal(spyStatic.callCount, 1);
+        assert.equal(spyError.callCount, 1);
+        // there won't be any image, because of error call
+        $img = element.get('_view').$el.find('img');
+        assert.equal($img.length, 0, "image not found");
+        window.console.error.restore();
 
-        $locate.trigger('click');
+        done();
       });
 
-    }); // END: suite('Form', ...)
+      assert.equal(spy.callCount, 0);
 
-  }); // END: suite('1', ...)
+      $locate.trigger('click');
+    });
+
+  }); // END: suite('Form', ...)
 
 });

--- a/test/23_1_location_native/test.js
+++ b/test/23_1_location_native/test.js
@@ -5,7 +5,7 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   window.MSApp = {};
 
-  if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
+  if (testUtils.isPhantom()) {
     return;
   }
 

--- a/test/23_location/test.js
+++ b/test/23_location/test.js
@@ -1,6 +1,6 @@
 define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
-  if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
+  if (testUtils.isPhantom()) {
     return;
   }
 

--- a/test/23_location/test.js
+++ b/test/23_location/test.js
@@ -1,163 +1,114 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
-  suite('23: Location field', function () {
-    var $doc = $(document),
-      $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
+    return;
+  }
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  testUtils.defineFormLoadSuite('TestForm', 'add');
+
+  suite('23: Location field', function () {
+
+    test('Render form with data', function (done) {
+      var form = Forms.current;
+
+      $.ajax({
+        type: "GET",
+        url: "getformrecord.xml",
+        dataType: "xml"}).then(
+        function (data) {
+          var record = {}, node, nodes;
+          nodes = data.evaluate('//' + form.attributes.name, data);
+          node = nodes.iterateNext();
+          _.each(node.children, function (key) {
+            record[key.nodeName] = key.innerHTML;
+          });
+          form.setRecord(record).then(function () {
+            form.data().then(function (formdata) {
+              var keys = ['id', 'location1', 'location2', '_action'];
+              _.each(keys, function (k) {
+                assert.ok(formdata[k], k + " does not exist");
+              });
+              done();
+            }, function () {
+              assert(false, "failed to set record");
+              done();
+            });
+          });
+        }
+     );
     });
 
-    suite('Form', function () {
+    test('location elements present', function (done) {
+      var elements = {'location1': 1, 'location2': 1, 'location3': 0, 'location4': 0},
+        element,
+        view;
 
-      if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
-        return;
-      }
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
+      _.each(elements, function (val, key) {
+        element = BMP.Forms.current.getElement(key);
+        view = element.attributes._view.$el.children('figure');
+        assert.lengthOf(view.children('img'), val);
       });
+      done();
+    });
 
-      test('initialise with form.json', function (done) {
-        var form;
+    test('location data is correct', function (done) {
+      var form = Forms.current,
+        elements = {
+          id: "1",
+          _action: "add",
+          location1: '{"latitude":-33.867487,"longitude":151.20699,"altitude":null,"accuracy":25000,"altitudeAccuracy":null,"heading":null,"speed":null}',
+          location2: '{"latitude":-33.867487,"longitude":151.20699,"altitude":null,"accuracy":25000,"altitudeAccuracy":null,"heading":null,"speed":null}'
+        };
 
-        Forms.getDefinition('TestForm', 'add').then(function (def) {
-          Forms.initialize(def, 'add');
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'TestForm');
-          assert.equal(form.get('label'), 'TestForm');
+      form.data().then(function (formdata) {
+        setTimeout(function () {
+          assert.deepEqual(formdata, elements, "form data");
           done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function (done) {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $doc.one('pageinit', function () {
-          done();
-        });
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-      test('Render form with data', function (done) {
-        var form = Forms.current;
-
-        $.ajax({
-          type: "GET",
-          url: "getformrecord.xml",
-          dataType: "xml"}).then(
-          function (data) {
-            var record = {}, node, nodes;
-            nodes = data.evaluate('//' + form.attributes.name, data);
-            node = nodes.iterateNext();
-            _.each(node.children, function (key) {
-              record[key.nodeName] = key.innerHTML;
-            });
-            form.setRecord(record).then(function () {
-              form.data().then(function (formdata) {
-                var keys = ['id', 'location1', 'location2', '_action'];
-                _.each(keys, function (k) {
-                  assert.ok(formdata[k], k + " does not exist");
-                });
-                done();
-              }, function () {
-                assert(false, "failed to set record");
-                done();
-              });
-            });
-          }
-       );
-      });
-
-      test('location elements present', function (done) {
-        var elements = {'location1': 1, 'location2': 1, 'location3': 0, 'location4': 0},
-          element,
-          view;
-
-        _.each(elements, function (val, key) {
-          element = BMP.Forms.current.getElement(key);
-          view = element.attributes._view.$el.children('figure');
-          assert.lengthOf(view.children('img'), val);
-        });
+        }, 0);
+      }, function () {
+        assert(false, "failed to set record");
         done();
       });
+    });
 
-      test('location data is correct', function (done) {
-        var form = Forms.current,
-          elements = {
-            id: "1",
-            _action: "add",
-            location1: '{"latitude":-33.867487,"longitude":151.20699,"altitude":null,"accuracy":25000,"altitudeAccuracy":null,"heading":null,"speed":null}',
-            location2: '{"latitude":-33.867487,"longitude":151.20699,"altitude":null,"accuracy":25000,"altitudeAccuracy":null,"heading":null,"speed":null}'
-          };
+    test('LOCATE button works as expected', function (done) {
+      var element = Forms.current.getElement('location4'),
+        $view = element.attributes._view.$el,
+        $add = $view.find('.ui-btn').children('button'),
+        $dialog,
+        keys = ['accuracy', 'altitude', 'altitudeAccuracy', 'heading', 'latitude', 'longitude', 'speed'],
+        value;
 
-        form.data().then(function (formdata) {
-          setTimeout(function () {
-            assert.deepEqual(formdata, elements, "form data");
-            done();
-          }, 0);
-        }, function () {
-          assert(false, "failed to set record");
-          done();
+      this.timeout(10000);
+
+      $add.trigger('click');
+
+      setTimeout(function () {
+        $dialog = $('#bmp-forms-location').find('button');
+        $dialog.first().trigger('click');
+        value = element.get('value');
+        _.each(keys, function (k) {
+          assert(_.has(value, k), k + " does not exist");
         });
-      });
+        done();
+      }, 7000);
+    });
 
-      test('LOCATE button works as expected', function (done) {
-        var element = Forms.current.getElement('location4'),
-          $view = element.attributes._view.$el,
-          $add = $view.find('.ui-btn').children('button'),
-          $dialog,
-          keys = ['accuracy', 'altitude', 'altitudeAccuracy', 'heading', 'latitude', 'longitude', 'speed'],
-          value;
+    test('CLEAR button works as expected', function (done) {
+      var element = Forms.current.getElement('location4'),
+        $view = element.attributes._view.$el,
+        $clear = $view.find('.ui-btn').children('button').last(),
+        value;
 
-        this.timeout(10000);
+      $clear.trigger('click');
 
-        $add.trigger('click');
-
-        setTimeout(function () {
-          $dialog = $('#bmp-forms-location').find('button');
-          $dialog.first().trigger('click');
+      setTimeout(function () {
           value = element.get('value');
-          _.each(keys, function (k) {
-            assert(_.has(value, k), k + " does not exist");
-          });
+          assert.notOk(value, "value still exists");
           done();
-        }, 7000);
-      });
+      }, 0);
+    });
 
-      test('CLEAR button works as expected', function (done) {
-        var element = Forms.current.getElement('location4'),
-          $view = element.attributes._view.$el,
-          $clear = $view.find('.ui-btn').children('button').last(),
-          value;
-
-        $clear.trigger('click');
-
-        setTimeout(function () {
-            value = element.get('value');
-            assert.notOk(value, "value still exists");
-            done();
-        }, 0);
-      });
-
-    }); // END: suite('Form', ...)
-
-  }); // END: suite('1', ...)
+  }); // END: suite('Form', ...)
 
 });

--- a/test/23_location/test.js
+++ b/test/23_location/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
     return;

--- a/test/24_images_multiplepages/test.js
+++ b/test/24_images_multiplepages/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   function isPhantom () {
     return navigator.userAgent.toLowerCase().indexOf('phantom') !== -1;

--- a/test/24_images_multiplepages/test.js
+++ b/test/24_images_multiplepages/test.js
@@ -1,9 +1,5 @@
 define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
-  function isPhantom () {
-    return navigator.userAgent.toLowerCase().indexOf('phantom') !== -1;
-  }
-
   testUtils.defineFormLoadSuite('TestForm', 'add');
 
   suite('24: Blob fields + multiple pages', function () {
@@ -72,7 +68,7 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
             element = form.getElement(i);
             if (v === 1) {
               view = element.attributes._view.$el;
-              if (isPhantom()) {
+              if (testUtils.isPhantom()) {
                 assert.lengthOf(view.children(), 2);
               } else {
                 assert.lengthOf(view.children(), 3);
@@ -118,7 +114,7 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
             element = form.getElement(i);
             if (v === 1) {
               view = element.attributes._view.$el;
-              if (isPhantom()) {
+              if (testUtils.isPhantom()) {
                 assert.lengthOf(view.children(), 2);
               } else {
                 assert.lengthOf(view.children(), 3);

--- a/test/24_images_multiplepages/test.js
+++ b/test/24_images_multiplepages/test.js
@@ -4,186 +4,137 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
     return navigator.userAgent.toLowerCase().indexOf('phantom') !== -1;
   }
 
-  suite('24: Blob fields + multiple pages', function () {
-    var $doc = $(document),
-      $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('TestForm', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  suite('24: Blob fields + multiple pages', function () {
+
+    test('Render form with data', function (done) {
+      var form = Forms.current;
+      $.ajax({
+        type: "GET",
+        url: "getformrecord.xml",
+        dataType: "xml"}).then(
+        function (data) {
+          var record = {}, node, nodes;
+
+          nodes = data.evaluate('//' + form.attributes.name, data);
+          node = nodes.iterateNext();
+          _.each(node.children, function (key) {
+            record[key.nodeName] = key.innerHTML;
+          });
+          form.setRecord(record).then(function () {
+            form.data().then(function (formdata) {
+              var keys = _.keys(record);
+              _.each(keys, function (k) {
+                assert.ok(formdata[k], k + " does not exist");
+              });
+              done();
+            }, function () {
+              assert(false, "failed to set record");
+              done();
+            });
+          });
+        }
+     );
     });
 
-    suite('Form', function () {
+    suite('verifying elements on Page:', function () {
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
+      suite('Page 0', function () {
 
-      test('initialise with form.json', function (done) {
-        var form;
+        var elements = {
+          "Photo": 1,
+          "Photo1": 1,
+          "Photo2": 0,
+          "location": 0,
+          "draw": 0
+        };
 
-        Forms.getDefinition('TestForm', 'add').then(function (def) {
-          Forms.initialize(def, 'add');
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'TestForm');
-          assert.equal(form.get('label'), 'TestForm');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
+        suiteSetup(function (done) {
+          var form = Forms.current,
+            pages = form.attributes.pages;
 
-      test('render form for jQuery Mobile', function (done) {
-        var form = Forms.current;
+          BMP.Forms.once('pageInjected', function () {
+            done();
+          });
 
-        $content.append(form.$form);
+          pages.goto(0);
 
-        $doc.one('pageinit', function () {
-          done();
         });
 
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
+        _.each(elements, function (v, i) {
 
-      testUtils.defineLabelTest();
-
-      test('Render form with data', function (done) {
-        var form = Forms.current;
-        $.ajax({
-          type: "GET",
-          url: "getformrecord.xml",
-          dataType: "xml"}).then(
-          function (data) {
-            var record = {}, node, nodes;
-
-            nodes = data.evaluate('//' + form.attributes.name, data);
-            node = nodes.iterateNext();
-            _.each(node.children, function (key) {
-              record[key.nodeName] = key.innerHTML;
-            });
-            form.setRecord(record).then(function () {
-              form.data().then(function (formdata) {
-                var keys = _.keys(record);
-                _.each(keys, function (k) {
-                  assert.ok(formdata[k], k + " does not exist");
-                });
-                done();
-              }, function () {
-                assert(false, "failed to set record");
-                done();
-              });
-            });
-          }
-       );
-      });
-
-      suite('verifying elements on Page:', function () {
-
-        suite('Page 0', function () {
-
-          var elements = {
-            "Photo": 1,
-            "Photo1": 1,
-            "Photo2": 0,
-            "location": 0,
-            "draw": 0
-          };
-
-          suiteSetup(function (done) {
+          test(i + ' should be ' + (v === 1 ? "visible" : "invisible"), function (done) {
             var form = Forms.current,
-              pages = form.attributes.pages;
+              element,
+              view;
 
-            BMP.Forms.once('pageInjected', function () {
-              done();
-            });
-
-            pages.goto(0);
-
-          });
-
-          _.each(elements, function (v, i) {
-
-            test(i + ' should be ' + (v === 1 ? "visible" : "invisible"), function (done) {
-              var form = Forms.current,
-                element,
-                view;
-
-              element = form.getElement(i);
-              if (v === 1) {
-                view = element.attributes._view.$el;
-                if (isPhantom()) {
-                  assert.lengthOf(view.children(), 2);
-                } else {
-                  assert.lengthOf(view.children(), 3);
-                  assert.lengthOf(view.children('figure').children('img'), 1);
-                }
+            element = form.getElement(i);
+            if (v === 1) {
+              view = element.attributes._view.$el;
+              if (isPhantom()) {
+                assert.lengthOf(view.children(), 2);
               } else {
-                assert.isUndefined(element.attributes._view);
+                assert.lengthOf(view.children(), 3);
+                assert.lengthOf(view.children('figure').children('img'), 1);
               }
+            } else {
+              assert.isUndefined(element.attributes._view);
+            }
 
-              done();
-            });
+            done();
           });
         });
-
-        suite('Page 1', function () {
-
-          var elements = {
-            "Photo": 0,
-            "Photo1": 0,
-            "Photo2": 1,
-            "location": 1,
-            "draw": 1
-          };
-
-          suiteSetup(function (done) {
-            var form = Forms.current,
-              pages = form.attributes.pages;
-
-            BMP.Forms.once('pageInjected', function () {
-              done();
-            });
-
-            pages.goto(1);
-          });
-
-          _.each(elements, function (v, i) {
-
-            test(i + ' should be ' + (v === 1 ? "visible" : "invisible"), function (done) {
-              var form = Forms.current,
-                element,
-                view;
-
-              element = form.getElement(i);
-              if (v === 1) {
-                view = element.attributes._view.$el;
-                if (isPhantom()) {
-                  assert.lengthOf(view.children(), 2);
-                } else {
-                  assert.lengthOf(view.children(), 3);
-                  assert.lengthOf(view.children('figure').children('img'), 1);
-                }
-              } else {
-                assert.isUndefined(element.attributes._view);
-              }
-
-              done();
-            });
-          });
-        });
-
       });
 
-    }); // END: suite('Form', ...)
+      suite('Page 1', function () {
 
-  }); // END: suite('1', ...)
+        var elements = {
+          "Photo": 0,
+          "Photo1": 0,
+          "Photo2": 1,
+          "location": 1,
+          "draw": 1
+        };
+
+        suiteSetup(function (done) {
+          var form = Forms.current,
+            pages = form.attributes.pages;
+
+          BMP.Forms.once('pageInjected', function () {
+            done();
+          });
+
+          pages.goto(1);
+        });
+
+        _.each(elements, function (v, i) {
+
+          test(i + ' should be ' + (v === 1 ? "visible" : "invisible"), function (done) {
+            var form = Forms.current,
+              element,
+              view;
+
+            element = form.getElement(i);
+            if (v === 1) {
+              view = element.attributes._view.$el;
+              if (isPhantom()) {
+                assert.lengthOf(view.children(), 2);
+              } else {
+                assert.lengthOf(view.children(), 3);
+                assert.lengthOf(view.children('figure').children('img'), 1);
+              }
+            } else {
+              assert.isUndefined(element.attributes._view);
+            }
+
+            done();
+          });
+        });
+      });
+
+    });
+
+  }); // END: suite('Form', ...)
 
 });

--- a/test/25_preloadSubform/test.js
+++ b/test/25_preloadSubform/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   suite('25: preload subForms and validate _action assignment', function () {
     var $doc = $(document),

--- a/test/26_cascadingSelects_add/test.js
+++ b/test/26_cascadingSelects_add/test.js
@@ -1,390 +1,348 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
+  if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
+    return;
+  }
+
+  testUtils.defineFormLoadSuite('form1', 'add');
+
   suite('26: cascading select boxes', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
 
-    if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
-      return;
-    }
+    test('Render form with data', function (done) {
+      var form = Forms.current;
+      $.ajax({
+        type: "GET",
+        url: "getformrecord.xml",
+        dataType: "xml"}).then(
+        function (data) {
+          var record = {}, node, nodes;
+          nodes = data.evaluate('//' + form.attributes.name, data);
+          node = nodes.iterateNext();
+          _.each(node.children, function (key) {
+            record[key.nodeName] = key.innerHTML;
+          });
+          form.setRecord(record).then(function () {
+            form.data().then(function (formdata) {
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+              var keys = ['id', 'country', 'city', 'state', 'form2', 'form3', '_action'];
+              _.each(keys, function (k) {
+                assert.ok(formdata[k], k + " does not exist");
+              });
+              done();
+            }, function () {
+              assert(false, "failed to set record");
+              done();
+            });
+          });
+        }
+     );
     });
 
-    suite('Form', function () {
+    suite('after .setRecord() from xml', function () {
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
+      var form;
+
+      suiteSetup(function (done) {
+        form = BMP.Forms.current;
+        done();
       });
 
-      test('initialise with form.json', function (done) {
-        var form;
+      test('PARENT: Cascading Selects are loaded correctly', function (done) {
+        var country = form.getElement('country'),
+          state = form.getElement('state'),
+          city = form.getElement('city'),
+          expected = {
+            country: {"Australia": "Australia", "India": "India"},
+            state: {
+              "NSW": "NSW",
+              "VIC": "VIC",
+              "QLD": "QLD",
+              "SA": "SA",
+              "TAS": "TAS",
+              "WA": "WA",
+              "NT": "NT",
+              "ACT": "ACT"
+            },
+            city: {
+              "10": "Gosford",
+              "11": "Sydney",
+              "12": "Woy Woy",
+              "13": "Wagga Wagga"
+            }
+          };
 
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
+        setTimeout(function () {
+          assert.deepEqual(expected.country, country.attributes.options);
+          assert.deepEqual(expected.state, state.attributes.options);
+          assert.deepEqual(expected.city, city.attributes.options);
           done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
+        }, 500);
       });
 
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-      test('Render form with data', function (done) {
-        var form = Forms.current;
-        $.ajax({
-          type: "GET",
-          url: "getformrecord.xml",
-          dataType: "xml"}).then(
-          function (data) {
-            var record = {}, node, nodes;
-            nodes = data.evaluate('//' + form.attributes.name, data);
-            node = nodes.iterateNext();
-            _.each(node.children, function (key) {
-              record[key.nodeName] = key.innerHTML;
-            });
-            form.setRecord(record).then(function () {
-              form.data().then(function (formdata) {
-
-                var keys = ['id', 'country', 'city', 'state', 'form2', 'form3', '_action'];
-                _.each(keys, function (k) {
-                  assert.ok(formdata[k], k + " does not exist");
-                });
-                done();
-              }, function () {
-                assert(false, "failed to set record");
-                done();
-              });
-            });
-          }
-       );
-      });
-
-      suite('after .setRecord() from xml', function () {
-
-        var form;
-
-        suiteSetup(function (done) {
-          form = BMP.Forms.current;
-          done();
-        });
-
-        test('PARENT: Cascading Selects are loaded correctly', function (done) {
-          var country = form.getElement('country'),
-            state = form.getElement('state'),
-            city = form.getElement('city'),
-            expected = {
-              country: {"Australia": "Australia", "India": "India"},
-              state: {
-                "NSW": "NSW",
-                "VIC": "VIC",
-                "QLD": "QLD",
-                "SA": "SA",
-                "TAS": "TAS",
-                "WA": "WA",
-                "NT": "NT",
-                "ACT": "ACT"
-              },
-              city: {
-                "10": "Gosford",
-                "11": "Sydney",
-                "12": "Woy Woy",
-                "13": "Wagga Wagga"
-              }
-            };
-
-          setTimeout(function () {
-            assert.deepEqual(expected.country, country.attributes.options);
-            assert.deepEqual(expected.state, state.attributes.options);
-            assert.deepEqual(expected.city, city.attributes.options);
-            done();
-          }, 500);
-        });
-
-        test('FORM2: Cascading Selects should load country+state correctly', function (done) {
-          var subformField = form.getElement("form2"),
-            country,
-            state,
-            city,
-            subform,
-            expected;
-
-            subform = subformField.getForm(0);
-
-            country = subform.getElement('country1');
-            state = subform.getElement('state1');
-            city = subform.getElement('city1');
-            expected = {
-              country: {"Australia": "Australia", "India": "India"},
-              state: {
-                "NSW": "NSW",
-                "VIC": "VIC",
-                "QLD": "QLD",
-                "SA": "SA",
-                "TAS": "TAS",
-                "WA": "WA",
-                "NT": "NT",
-                "ACT": "ACT"
-              },
-              city: {
-                "a": "a",
-                "b": "b"
-              }
-            };
-
-          setTimeout(function () {
-            assert.deepEqual(expected.country, country.attributes.options);
-            assert.deepEqual(expected.state, state.attributes.options);
-            assert.deepEqual(expected.city, city.attributes.options);
-            done();
-          }, 500);
-        });
-
-        test('FORM3: Cascading Selects should not load anything', function (done) {
-          var subformField = form.getElement("form3"),
-            country,
-            state,
-            city,
-            subform,
-            expected;
+      test('FORM2: Cascading Selects should load country+state correctly', function (done) {
+        var subformField = form.getElement("form2"),
+          country,
+          state,
+          city,
+          subform,
+          expected;
 
           subform = subformField.getForm(0);
 
-          country = subform.getElement('field1');
-          state = subform.getElement('field2');
-          city = subform.getElement('field3');
+          country = subform.getElement('country1');
+          state = subform.getElement('state1');
+          city = subform.getElement('city1');
           expected = {
-            country: {"a": "a", "b": "b"},
-            state: {"a": "a", "b": "b"},
-            city: {"a": "a", "b": "b"}
+            country: {"Australia": "Australia", "India": "India"},
+            state: {
+              "NSW": "NSW",
+              "VIC": "VIC",
+              "QLD": "QLD",
+              "SA": "SA",
+              "TAS": "TAS",
+              "WA": "WA",
+              "NT": "NT",
+              "ACT": "ACT"
+            },
+            city: {
+              "a": "a",
+              "b": "b"
+            }
           };
 
-          setTimeout(function () {
-            assert.deepEqual(expected.country, country.attributes.options);
-            assert.deepEqual(expected.state, state.attributes.options);
-            assert.deepEqual(expected.city, city.attributes.options);
-            done();
-          }, 500);
-        });
-
-      }); // END: suite('after .setRecord() from xml', ...)
-
-      suite('change parent values', function () {
-
-        var form;
-
-        suiteSetup(function (done) {
-          form = BMP.Forms.current;
+        setTimeout(function () {
+          assert.deepEqual(expected.country, country.attributes.options);
+          assert.deepEqual(expected.state, state.attributes.options);
+          assert.deepEqual(expected.city, city.attributes.options);
           done();
-        });
+        }, 500);
+      });
 
-        test('change country and state should update', function (done) {
-          var country = form.getElement('country'),
-            state = form.getElement('state'),
-            city = form.getElement('city'),
-            expected = {
-              country: {"Australia": "Australia", "India": "India"},
-              state: {
-                "Gujarat": "Gujarat",
-                "Maharashtra": "Maharashtra",
-                "Rajasthan": "Rajasthan"
-              },
-              city: {
-                "10": "Gosford",
-                "11": "Sydney",
-                "12": "Woy Woy",
-                "13": "Wagga Wagga"
-              }
-            };
+      test('FORM3: Cascading Selects should not load anything', function (done) {
+        var subformField = form.getElement("form3"),
+          country,
+          state,
+          city,
+          subform,
+          expected;
 
-          country.set('value', "India");
+        subform = subformField.getForm(0);
 
-          setTimeout(function () {
-            assert.deepEqual(expected.country, country.attributes.options);
-            assert.deepEqual(expected.state, state.attributes.options);
-            assert.deepEqual(expected.city, city.attributes.options);
-            done();
-          }, 500);
-        });
+        country = subform.getElement('field1');
+        state = subform.getElement('field2');
+        city = subform.getElement('field3');
+        expected = {
+          country: {"a": "a", "b": "b"},
+          state: {"a": "a", "b": "b"},
+          city: {"a": "a", "b": "b"}
+        };
 
-        test('change state and city should update', function (done) {
-          var country = form.getElement('country'),
-            state = form.getElement('state'),
-            city = form.getElement('city'),
-            expected = {
-              country: {"Australia": "Australia", "India": "India"},
-              state: {
-                "Gujarat": "Gujarat",
-                "Maharashtra": "Maharashtra",
-                "Rajasthan": "Rajasthan"
-              },
-              city: {
-                "107": "Udaypur",
-                "108": "Jaipur"
-              }
-            };
-
-          state.set('value', "Rajasthan");
-
-          setTimeout(function () {
-            assert.deepEqual(expected.country, country.attributes.options);
-            assert.deepEqual(expected.state, state.attributes.options);
-            assert.deepEqual(expected.city, city.attributes.options);
-            done();
-          }, 500);
-        });
-      }); // END: suite('change parent values', ...)
-
-      suite('change form2 values', function () {
-
-        var form, subform;
-
-        suiteSetup(function (done) {
-          form = BMP.Forms.current;
-          subform = form.getElement('form2').getForm(0);
+        setTimeout(function () {
+          assert.deepEqual(expected.country, country.attributes.options);
+          assert.deepEqual(expected.state, state.attributes.options);
+          assert.deepEqual(expected.city, city.attributes.options);
           done();
-        });
+        }, 500);
+      });
 
-        test('country should contain new options', function (done) {
-          var country,
-            expected;
+    }); // END: suite('after .setRecord() from xml', ...)
 
-          country = subform.getElement('country1');
-          expected = {"Australia": "Australia", "India": "India"};
+    suite('change parent values', function () {
 
-          setTimeout(function () {
-            assert.deepEqual(expected, country.attributes.options);
-            done();
-          }, 500);
-        });
+      var form;
 
-        test('change country and state should update', function (done) {
-          var country = subform.getElement('country1'),
-            state = subform.getElement('state1'),
-            city = subform.getElement('city1'),
-            expected = {
-              state1: {
-                "Gujarat": "Gujarat",
-                "Maharashtra": "Maharashtra",
-                "Rajasthan": "Rajasthan"
-              },
-              city1: {
-                "a": "a",
-                "b": "b"
-              }
-            };
+      suiteSetup(function (done) {
+        form = BMP.Forms.current;
+        done();
+      });
 
-          country.set("value", "India");
+      test('change country and state should update', function (done) {
+        var country = form.getElement('country'),
+          state = form.getElement('state'),
+          city = form.getElement('city'),
+          expected = {
+            country: {"Australia": "Australia", "India": "India"},
+            state: {
+              "Gujarat": "Gujarat",
+              "Maharashtra": "Maharashtra",
+              "Rajasthan": "Rajasthan"
+            },
+            city: {
+              "10": "Gosford",
+              "11": "Sydney",
+              "12": "Woy Woy",
+              "13": "Wagga Wagga"
+            }
+          };
 
-          setTimeout(function () {
-            assert.deepEqual(expected.state1, state.attributes.options);
-            assert.deepEqual(expected.city1, city.attributes.options);
-            done();
-          }, 500);
-        });
+        country.set('value', "India");
 
-        test('change state and city should not update (cascade resource does not exist)', function (done) {
-          var state = subform.getElement('state1'),
-            city = subform.getElement('city1'),
-            expected = {
+        setTimeout(function () {
+          assert.deepEqual(expected.country, country.attributes.options);
+          assert.deepEqual(expected.state, state.attributes.options);
+          assert.deepEqual(expected.city, city.attributes.options);
+          done();
+        }, 500);
+      });
+
+      test('change state and city should update', function (done) {
+        var country = form.getElement('country'),
+          state = form.getElement('state'),
+          city = form.getElement('city'),
+          expected = {
+            country: {"Australia": "Australia", "India": "India"},
+            state: {
+              "Gujarat": "Gujarat",
+              "Maharashtra": "Maharashtra",
+              "Rajasthan": "Rajasthan"
+            },
+            city: {
+              "107": "Udaypur",
+              "108": "Jaipur"
+            }
+          };
+
+        state.set('value', "Rajasthan");
+
+        setTimeout(function () {
+          assert.deepEqual(expected.country, country.attributes.options);
+          assert.deepEqual(expected.state, state.attributes.options);
+          assert.deepEqual(expected.city, city.attributes.options);
+          done();
+        }, 500);
+      });
+    }); // END: suite('change parent values', ...)
+
+    suite('change form2 values', function () {
+
+      var form, subform;
+
+      suiteSetup(function (done) {
+        form = BMP.Forms.current;
+        subform = form.getElement('form2').getForm(0);
+        done();
+      });
+
+      test('country should contain new options', function (done) {
+        var country,
+          expected;
+
+        country = subform.getElement('country1');
+        expected = {"Australia": "Australia", "India": "India"};
+
+        setTimeout(function () {
+          assert.deepEqual(expected, country.attributes.options);
+          done();
+        }, 500);
+      });
+
+      test('change country and state should update', function (done) {
+        var country = subform.getElement('country1'),
+          state = subform.getElement('state1'),
+          city = subform.getElement('city1'),
+          expected = {
+            state1: {
+              "Gujarat": "Gujarat",
+              "Maharashtra": "Maharashtra",
+              "Rajasthan": "Rajasthan"
+            },
+            city1: {
+              "a": "a",
+              "b": "b"
+            }
+          };
+
+        country.set("value", "India");
+
+        setTimeout(function () {
+          assert.deepEqual(expected.state1, state.attributes.options);
+          assert.deepEqual(expected.city1, city.attributes.options);
+          done();
+        }, 500);
+      });
+
+      test('change state and city should not update (cascade resource does not exist)', function (done) {
+        var state = subform.getElement('state1'),
+          city = subform.getElement('city1'),
+          expected = {
+            "a": "a",
+            "b": "b"
+          };
+
+        state.set('value', "Gujarat");
+
+        setTimeout(function () {
+          assert.deepEqual(expected, city.attributes.options);
+          done();
+        }, 500);
+      });
+
+    }); // END: suite('change form2 values', ...)
+
+    suite('change form3 values', function () {
+
+      var form, subform;
+
+      suiteSetup(function (done) {
+        form = BMP.Forms.current;
+        subform = form.getElement('form3').getForm(0);
+        done();
+      });
+
+      test('country should contain old options (cascade fails)', function (done) {
+        var country,
+          expected;
+
+        country = subform.getElement('field1');
+        expected = {"a": "a", "b": "b"};
+
+        setTimeout(function () {
+          assert.deepEqual(expected, country.attributes.options);
+          done();
+        }, 500);
+      });
+
+      test('change country and nothing will change (cascade resource does not exist)', function (done) {
+        var country = subform.getElement('field1'),
+          state = subform.getElement('field2'),
+          city = subform.getElement('field3'),
+          expected = {
+            state: {
+              "a": "a",
+              "b": "b"
+            },
+            city: {
+              "a": "a",
+              "b": "b"
+            }
+          };
+
+        country.set("value", "b");
+
+        setTimeout(function () {
+          assert.deepEqual(expected.state, state.attributes.options);
+          assert.deepEqual(expected.city, city.attributes.options);
+          done();
+        }, 500);
+      });
+
+      test('change state and city should not update (cascade resource does not exist)', function (done) {
+        var state = subform.getElement('field2'),
+          city = subform.getElement('field3'),
+          expected = {
               "a": "a",
               "b": "b"
             };
 
-          state.set('value', "Gujarat");
+        state.set('value', "b");
 
-          setTimeout(function () {
-            assert.deepEqual(expected, city.attributes.options);
-            done();
-          }, 500);
-        });
-
-      }); // END: suite('change form2 values', ...)
-
-      suite('change form3 values', function () {
-
-        var form, subform;
-
-        suiteSetup(function (done) {
-          form = BMP.Forms.current;
-          subform = form.getElement('form3').getForm(0);
+        setTimeout(function () {
+          assert.deepEqual(expected, city.attributes.options);
           done();
-        });
+        }, 500);
+      });
 
-        test('country should contain old options (cascade fails)', function (done) {
-          var country,
-            expected;
-
-          country = subform.getElement('field1');
-          expected = {"a": "a", "b": "b"};
-
-          setTimeout(function () {
-            assert.deepEqual(expected, country.attributes.options);
-            done();
-          }, 500);
-        });
-
-        test('change country and nothing will change (cascade resource does not exist)', function (done) {
-          var country = subform.getElement('field1'),
-            state = subform.getElement('field2'),
-            city = subform.getElement('field3'),
-            expected = {
-              state: {
-                "a": "a",
-                "b": "b"
-              },
-              city: {
-                "a": "a",
-                "b": "b"
-              }
-            };
-
-          country.set("value", "b");
-
-          setTimeout(function () {
-            assert.deepEqual(expected.state, state.attributes.options);
-            assert.deepEqual(expected.city, city.attributes.options);
-            done();
-          }, 500);
-        });
-
-        test('change state and city should not update (cascade resource does not exist)', function (done) {
-          var state = subform.getElement('field2'),
-            city = subform.getElement('field3'),
-            expected = {
-                "a": "a",
-                "b": "b"
-              };
-
-          state.set('value', "b");
-
-          setTimeout(function () {
-            assert.deepEqual(expected, city.attributes.options);
-            done();
-          }, 500);
-        });
-      }); // END: suite('change form3 values', ...)
-    }); // END: suite('Form', ...)
+    }); // END: suite('change form3 values', ...)
 
   }); // END: suite('1', ...)
 

--- a/test/26_cascadingSelects_add/test.js
+++ b/test/26_cascadingSelects_add/test.js
@@ -1,6 +1,6 @@
 define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
-  if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
+  if (testUtils.isPhantom()) {
     return;
   }
 

--- a/test/26_cascadingSelects_add/test.js
+++ b/test/26_cascadingSelects_add/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
     return;

--- a/test/27_performance/test.js
+++ b/test/27_performance/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
   // var start, end, interval, intervals;
 
   // suite('responsiveness test', function () {

--- a/test/28_MaxSubforms/test.js
+++ b/test/28_MaxSubforms/test.js
@@ -1,6 +1,6 @@
 define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
-  if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
+  if (testUtils.isPhantom()) {
     return;
   }
 

--- a/test/28_MaxSubforms/test.js
+++ b/test/28_MaxSubforms/test.js
@@ -1,54 +1,14 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
+  if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
+    return;
+  }
+
+  testUtils.defineFormLoadSuite('form1', 'edit');
+
   suite('28: MaxSubforms', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
-
-    if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
-      return;
-    }
-
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-    });
 
     suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('form1', 'edit').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
 
       test('Render form with data', function (done) {
         var form = Forms.current;

--- a/test/28_MaxSubforms/test.js
+++ b/test/28_MaxSubforms/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   if (navigator.userAgent.toLowerCase().indexOf('phantom') !== -1) {
     return;

--- a/test/29_AllFields/test.js
+++ b/test/29_AllFields/test.js
@@ -1,51 +1,8 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
+  testUtils.defineFormLoadSuite('test_form', 'add');
+
   suite('29: AllFields', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
-
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-    });
-
-    suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('test_form', 'edit').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'test_form');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-    }); // END: suite('Form', ...)
 
     suite('label as empty placeholders for aligning', function () {
       var form;

--- a/test/29_AllFields/test.js
+++ b/test/29_AllFields/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('test_form', 'add');
 

--- a/test/29_external_errors/test.js
+++ b/test/29_external_errors/test.js
@@ -1,29 +1,12 @@
-define(['BlinkForms', 'BIC'], function (Forms) {
+define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
   suite('29: External Errors', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
 
-    setup(function (done) {
-      Forms.getDefinition('form1', 'edit').then(function (def) {
-          Forms.initialize(def);
-          $content.append(Forms.current.$form);
-          $.mobile.page({}, $page);
-          $page.trigger('pagecreate');
-          $page.show();
-          Forms.current.set('numErrorsShown', 0); // dont want a limit
-          done();
-        }, function () {
-          assert.fail(true, false, 'Setup Failed');
-          done();
-        });
-    });
-
-    teardown(function () {
-      // commented out so that the last test can leave a functional DOM in place so we can
-      // manually test
-      // $content.empty();
-      // delete Forms.current;
+    setup(function () {
+      return testUtils.loadForm('form1', 'edit')
+      .then(function () {
+        Forms.current.set('numErrorsShown', 0); // dont want a limit
+      });
     });
 
     test('External errors set show up on form', function () {
@@ -36,9 +19,6 @@ define(['BlinkForms', 'BIC'], function (Forms) {
 
       assert.isAbove(element.get('_view').$el.find('.bm-errors__bm-listitem').text().indexOf('This is custom text'), -1);
       assert.equal(element.validationError.value[0].CUSTOM, 'This is custom text');
-
-      $content.empty();
-      delete Forms.current;
     });
 
     test('External errors set show up on form when set on an element model', function () {
@@ -50,9 +30,6 @@ define(['BlinkForms', 'BIC'], function (Forms) {
 
       assert.isAbove(element.get('_view').$el.find('.bm-errors__bm-listitem').text().indexOf('This is custom text'), -1);
       assert.equal(element.validationError.value[0].CUSTOM, 'This is custom text');
-
-      $content.empty();
-      delete Forms.current;
     });
 
     test('External errors override built in errors of the same name', function () {
@@ -63,9 +40,6 @@ define(['BlinkForms', 'BIC'], function (Forms) {
       element.val('afdasdasdaf');
       Forms.current.setErrors(externalErrors);
       assert.equal(element.validationError.value[0].MAX, 5);
-
-      $content.empty();
-      delete Forms.current;
     });
 
     test('External errors should be cleared when field is altered', function () {
@@ -74,9 +48,6 @@ define(['BlinkForms', 'BIC'], function (Forms) {
       element.val('1');
 
       assert.isTrue(!element.validationError);
-
-      $content.empty();
-      delete Forms.current;
     });
 
     test('External errors should merge by default', function () {
@@ -91,9 +62,6 @@ define(['BlinkForms', 'BIC'], function (Forms) {
 
       Forms.current.setErrors(externalErrors);
       assert.equal(element.validationError.value.length, 2);
-
-      $content.empty();
-      delete Forms.current;
     });
 
     test('External errors should be at the front of the errors array', function () {
@@ -109,9 +77,6 @@ define(['BlinkForms', 'BIC'], function (Forms) {
 
       Forms.current.setErrors(externalErrors);
       assert.equal(element.validationError.value[0].code, 'CUSTOM');
-
-      $content.empty();
-      delete Forms.current;
     });
 
 // //////////////////////////////////////////////////////////////////////////////////
@@ -159,9 +124,6 @@ define(['BlinkForms', 'BIC'], function (Forms) {
 
           assert.equal(errorMessages[0].code, 'CUSTOM');
           assert.equal(errorMessages[0].CUSTOM, 'this is a custom subform element error');
-
-          $content.empty();
-          delete Forms.current;
       });
 
       test('We can set a custom error message on an element in a specific subform', function () {

--- a/test/29_external_errors/test.js
+++ b/test/29_external_errors/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   suite('29: External Errors', function () {
 

--- a/test/2_choices/test.js
+++ b/test/2_choices/test.js
@@ -7,699 +7,655 @@ define(['BlinkForms', 'testUtils', 'underscore', 'BIC'], function (Forms, testUt
   var multiWithOther = [ 'multic', 'multie', 'multif', 'multig' ];
   var selectWithOther = [ 'selectc', 'selecte', 'selectf', 'selecth' ];
 
-  suite('2: options', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('form1', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  suite('2: options', function () {
+
+    test('select+other bindings between model and "other" input', function () {
+      var form = Forms.current;
+      selectWithOther.forEach(function (name) {
+        var value;
+        var element = form.getElement(name);
+        var $view = element.get('_view').$el;
+        var $other;
+        var $checked;
+
+        element.val('');
+        $other = $view.find('input[type=text]');
+        assert.notOk(element.val(), name + ': model value is falsey');
+        // assert.lengthOf($selected, 0, name + ': nothing checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+
+        value = 'a';
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.equal(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 1, name + ': 1 checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+        assert.equal($checked.val(), value, name + ': model value correct');
+
+        value = '123';
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 1, name + ': 1 checked');
+        assert.lengthOf($other, 1, name + ': other box present');
+        assert.equal($other.val(), '123', name + ': other box shows "123"');
+        assert.equal($checked.val(), 'other', name + ': model value correct');
+
+        element.val('');
+        $other = $view.find('input[type=text]');
+        assert.notOk(element.val(), name + ': model value is falsey');
+        // assert.lengthOf($selected, 0, name + ': nothing checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+
+        if (element.get('nativeMenu')) {
+          assert.equal($view.find('select').data("role"), "none", name + ': data-role is not none');
+        } else {
+          assert.notEqual($view.find('select').data("role"), "none", name + ': data-role is not none');
+        }
+      });
     });
 
-    suite('Form', function () {
+    test('multi+other bindings between model and "other" input', function () {
+      var form = Forms.current;
+      multiWithOther.forEach(function (name) {
+        var value;
+        var element = form.getElement(name);
+        var $view = element.get('_view').$el;
+        var $other;
+        var $checked;
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
+        element.val('');
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.notOk(element.val(), name + ': model value is falsey');
+        assert.lengthOf($checked, 0, name + ': nothing checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+
+        value = ['a'];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 1, name + ': 1 checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+        assert.deepEqual($checked.map(function () {
+          return $(this).val();
+        }).get(), value, name + ': model value correct');
+
+        value = ['a', 'b'];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 2, name + ': 2 checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+        assert.deepEqual($checked.map(function () {
+          return $(this).val();
+        }).get(), value, name + ': model value correct');
+
+        value = [''];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 1, name + ': 1 checked');
+        assert.lengthOf($other, 1, name + ': other box present');
+        assert.equal($other.val(), '', name + ': other box empty');
+
+        value = ['a', ''];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 2, name + ': 2 checked');
+        assert.lengthOf($other, 1, name + ': other box present');
+        assert.equal($other.val(), '', name + ': other box empty');
+        assert.deepEqual($checked.map(function () {
+          return $(this).val();
+        }).get(), ['a', 'other'], name + ': model value correct');
+
+        value = ['123'];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 1, name + ': 1 checked');
+        assert.lengthOf($other, 1, name + ': other box present');
+        assert.equal($other.val(), '123', name + ': other box shows "123"');
+        assert.deepEqual($checked.map(function () {
+          return $(this).val();
+        }).get(), ['other'], name + ': model value correct');
+
+        value = ['a', '123'];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 2, name + ': 2 checked');
+        assert.lengthOf($other, 1, name + ': other box present');
+        assert.equal($other.val(), '123', name + ': other box shows "123"');
+        assert.deepEqual($checked.map(function () {
+          return $(this).val();
+        }).get(), ['a', 'other'], name + ': model value correct');
+
+        element.val('');
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.notOk(element.val(), name + ': model value is falsey');
+        assert.lengthOf($checked, 0, name + ': nothing checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+
+        if (element.get('nativeMenu')) {
+          assert.equal($view.find('select').data("role"), "none", name + ': data-role is not none');
+        } else {
+          assert.notEqual($view.find('select').data("role"), "none", name + ': data-role is not none');
+        }
       });
+    });
 
-      test('initialise with form.json', function (done) {
-        var form;
+    test('Multi-F native collapsed', function () {
+      var form = Forms.current,
+        element = form.getElement('multif'),
+        $fieldset = element.attributes._view.$el,
+        $select = $fieldset.find('select');
 
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
+      element.val([]);
+      assert.deepEqual(element.val(), [], 'model.value is []');
 
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
+      element.val(['a']);
+      assert.deepEqual(element.val(), ['a'], 'model.value = ["a"]');
 
-        $content.append(form.$form);
+      element.val(['a', 'b']);
+      assert.deepEqual(element.val(), ['a', 'b'], 'model.value = ["a", "b"]');
 
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
+      assert.equal($select.data("role"), "none", "data-role is not none");
 
-      testUtils.defineLabelTest();
+    });
 
-      test('select+other bindings between model and "other" input', function () {
-        var form = Forms.current;
-        selectWithOther.forEach(function (name) {
-          var value;
-          var element = form.getElement(name);
-          var $view = element.get('_view').$el;
-          var $other;
-          var $checked;
+    ['boolean', 'question'].forEach(function (name) {
 
-          element.val('');
-          $other = $view.find('input[type=text]');
-          assert.notOk(element.val(), name + ': model value is falsey');
-          // assert.lengthOf($selected, 0, name + ': nothing checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-
-          value = 'a';
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.equal(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 1, name + ': 1 checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-          assert.equal($checked.val(), value, name + ': model value correct');
-
-          value = '123';
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 1, name + ': 1 checked');
-          assert.lengthOf($other, 1, name + ': other box present');
-          assert.equal($other.val(), '123', name + ': other box shows "123"');
-          assert.equal($checked.val(), 'other', name + ': model value correct');
-
-          element.val('');
-          $other = $view.find('input[type=text]');
-          assert.notOk(element.val(), name + ': model value is falsey');
-          // assert.lengthOf($selected, 0, name + ': nothing checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-
-          if (element.get('nativeMenu')) {
-            assert.equal($view.find('select').data("role"), "none", name + ': data-role is not none');
-          } else {
-            assert.notEqual($view.find('select').data("role"), "none", name + ': data-role is not none');
-          }
-        });
-      });
-
-      test('multi+other bindings between model and "other" input', function () {
-        var form = Forms.current;
-        multiWithOther.forEach(function (name) {
-          var value;
-          var element = form.getElement(name);
-          var $view = element.get('_view').$el;
-          var $other;
-          var $checked;
-
-          element.val('');
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.notOk(element.val(), name + ': model value is falsey');
-          assert.lengthOf($checked, 0, name + ': nothing checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-
-          value = ['a'];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 1, name + ': 1 checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-          assert.deepEqual($checked.map(function () {
-            return $(this).val();
-          }).get(), value, name + ': model value correct');
-
-          value = ['a', 'b'];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 2, name + ': 2 checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-          assert.deepEqual($checked.map(function () {
-            return $(this).val();
-          }).get(), value, name + ': model value correct');
-
-          value = [''];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 1, name + ': 1 checked');
-          assert.lengthOf($other, 1, name + ': other box present');
-          assert.equal($other.val(), '', name + ': other box empty');
-
-          value = ['a', ''];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 2, name + ': 2 checked');
-          assert.lengthOf($other, 1, name + ': other box present');
-          assert.equal($other.val(), '', name + ': other box empty');
-          assert.deepEqual($checked.map(function () {
-            return $(this).val();
-          }).get(), ['a', 'other'], name + ': model value correct');
-
-          value = ['123'];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 1, name + ': 1 checked');
-          assert.lengthOf($other, 1, name + ': other box present');
-          assert.equal($other.val(), '123', name + ': other box shows "123"');
-          assert.deepEqual($checked.map(function () {
-            return $(this).val();
-          }).get(), ['other'], name + ': model value correct');
-
-          value = ['a', '123'];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 2, name + ': 2 checked');
-          assert.lengthOf($other, 1, name + ': other box present');
-          assert.equal($other.val(), '123', name + ': other box shows "123"');
-          assert.deepEqual($checked.map(function () {
-            return $(this).val();
-          }).get(), ['a', 'other'], name + ': model value correct');
-
-          element.val('');
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.notOk(element.val(), name + ': model value is falsey');
-          assert.lengthOf($checked, 0, name + ': nothing checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-
-          if (element.get('nativeMenu')) {
-            assert.equal($view.find('select').data("role"), "none", name + ': data-role is not none');
-          } else {
-            assert.notEqual($view.find('select').data("role"), "none", name + ': data-role is not none');
-          }
-        });
-      });
-
-      test('Multi-F native collapsed', function () {
+      test(name + ': model->view', function (done) {
         var form = Forms.current,
-          element = form.getElement('multif'),
-          $fieldset = element.attributes._view.$el,
-          $select = $fieldset.find('select');
-
-        element.val([]);
-        assert.deepEqual(element.val(), [], 'model.value is []');
-
-        element.val(['a']);
-        assert.deepEqual(element.val(), ['a'], 'model.value = ["a"]');
-
-        element.val(['a', 'b']);
-        assert.deepEqual(element.val(), ['a', 'b'], 'model.value = ["a", "b"]');
-
-        assert.equal($select.data("role"), "none", "data-role is not none");
-
-      });
-
-      ['boolean', 'question'].forEach(function (name) {
-
-        test(name + ': model->view', function (done) {
-          var form = Forms.current,
-            element = form.getElement(name),
-            options = Object.keys(element.get('options')),
-            $fieldset = element.attributes._view.$el;
-
-          Promise.resolve()
-          .then(function () {
-            element.val('');
-            return testUtils.wait(500);
-          })
-          .then(function () {
-            assert.equal(element.val(), options[0], name + ': default value');
-            assert.equal($fieldset.find('.ui-btn-active').css('width'), '0px');
-
-            element.val(options[0]);
-            return testUtils.wait(500);
-          })
-          .then(function () {
-            assert.equal(element.val(), options[0], name + ': value=' + options[0]);
-            assert.equal($fieldset.find('.ui-btn-active').css('width'), '0px');
-
-            element.val(options[1]);
-            return testUtils.wait(500);
-          })
-          .then(function () {
-            assert.equal(element.val(), options[1], name + ': value=' + options[1]);
-            assert.notEqual($fieldset.find('.ui-btn-active').css('width'), '0px');
-          })
-          .then(done, done);
-
-        });
-
-        test(name + ': view->model', function (done) {
-          var form = Forms.current,
-            element = form.getElement(name),
-            options = Object.keys(element.get('options')),
-            $fieldset = element.attributes._view.$el;
-
-          Promise.resolve()
-          .then(function () {
-            element.val('');
-            return testUtils.wait(500);
-          })
-          .then(function () {
-            assert.equal(element.val(), options[0], name + ': default value');
-            assert.equal($fieldset.find('.ui-btn-active').css('width'), '0px');
-
-            $fieldset.find('div.ui-slider-switch').trigger('mousedown').trigger('mouseup').trigger('click');
-            return testUtils.wait(500);
-          })
-          .then(function () {
-            assert.equal(element.val(), options[1], name + ': value=' + options[1]);
-            assert.notEqual($fieldset.find('.ui-btn-active').css('width'), '0px');
-
-            $fieldset.find('div.ui-slider-switch').trigger('mousedown').trigger('mouseup').trigger('click');
-            return testUtils.wait(500);
-          })
-          .then(function () {
-            assert.equal(element.val(), options[0], name + ': value=' + options[0]);
-            assert.equal($fieldset.find('.ui-btn-active').css('width'), '0px');
-          })
-          .then(done, done);
-
-        });
-
-      });
-
-      ['selectc', 'multic', 'multif', 'multig', 'multiee'].forEach(function (name) {
-
-        test(name + ': model->view', function () {
-          var form = Forms.current,
-            element = form.getElement(name),
-            $el = element.attributes._view.$el;
-
-          if (element.attributes.type === 'multi') {
-            element.val(['b']);
-          } else {
-            element.val('b');
-          }
-          assert.equal($el.find('.ui-select .ui-btn-text').text(), 'beta');
-
-          element.val('');
-          if (element.attributes.type === 'multi') {
-            assert.equal($el.find('.ui-select .ui-btn-text').text(), 'select one or more...');
-          } else {
-            assert.equal($el.find('.ui-select .ui-btn-text').text(), 'select one...');
-          }
-        });
-
-        test(name + ': view->model', function () {
-          var form = Forms.current;
-          var element = form.getElement(name);
-          var $el = element.attributes._view.$el;
-          var $a = $el.children('.ui-select').find('[role=button]');
-          var $popup;
-          var $item;
-
-          $a.trigger('click');
-          $popup = $($a.attr('href'));
-          assert.lengthOf($popup, 1);
-
-          $item = $popup.find('[data-option-index=3]');
-          assert.equal($item.text().trim(), 'gamma');
-
-          $item.find('a').trigger('click');
-          if (element.attributes.type === 'multi') {
-            assert.deepEqual(element.val(), ['g']);
-          } else {
-            assert.equal(element.val(), 'g');
-          }
-        });
-      });
-
-      ['selectf', 'selecth'].forEach(function (name) {
-
-        test(name + ': model->view', function () {
-          var form = Forms.current,
-            element = form.getElement(name),
-            $el = element.attributes._view.$el;
-
-          element.val('b');
-          assert.equal($el.find('select').val(), 'b');
-
-          element.val('');
-          assert($el.find('select').val());
-        });
-
-        test(name + ': view->model', function () {
-          var form = Forms.current,
-            element = form.getElement(name),
-            $el = element.attributes._view.$el;
-
-          $el.find('select').val('g').trigger('change');
-          assert.equal(element.val(), 'g');
-        });
-
-      });
-
-      ['selecte', 'multie'].forEach(function (name) {
-
-        test(name + ': model->view', function () {
-          var form = Forms.current,
-            element = form.getElement(name),
-            $el = element.attributes._view.$el;
-
-          if (element.attributes.type === 'multi') {
-            element.val(['b']);
-            assert.equal($el.find('.ui-checkbox-on').text().trim(), 'beta');
-          } else {
-            element.val('b');
-            assert.equal($el.find('.ui-radio-on').text().trim(), 'beta');
-          }
-
-          if (element.attributes.type === 'multi') {
-            element.val([]);
-            assert.lengthOf($el.find('.ui-checkbox-on'), 0);
-          } else {
-            element.val('');
-            assert.lengthOf($el.find('.ui-radio-on'), 0);
-          }
-        });
-
-        test(name + ': view->model', function () {
-          var form = Forms.current,
-            element = form.getElement(name),
-            $el = element.attributes._view.$el;
-
-          if (element.attributes.type === 'multi') {
-            $el.find('.ui-checkbox').eq(2).children('label').trigger('click');
-            assert.deepEqual(element.val(), ['g']);
-          } else {
-            $el.find('.ui-radio').eq(2).children('label').trigger('click');
-            assert.equal(element.val(), 'g');
-          }
-        });
-
-      });
-
-      test('elements have original a|b|g options', function () {
-        var form = Forms.current;
-        choiceElements.forEach(function (name) {
-          var element = form.getElement(name);
-          var currentOptions = element.get('options');
-          assert.deepEqual(currentOptions, originalOptions, name + ' ' + JSON.stringify(currentOptions));
-        });
-      });
-
-      test('elements set to d|e|z options', function () {
-        var form = Forms.current;
-        choiceElements.forEach(function (name) {
-          var element = form.getElement(name);
-          // var currentOptions = element.get('options');
-          element.set('options', newOptions);
-        });
-      });
-
-      test('select+other bindings between model and "other" input', function () {
-        var form = Forms.current;
-        selectWithOther.forEach(function (name) {
-          var value;
-          var element = form.getElement(name);
-          var $view = element.get('_view').$el;
-          var $other;
-          var $checked;
-
-          element.val('');
-          $other = $view.find('input[type=text]');
-          assert.notOk(element.val(), name + ': model value is falsey');
-          // assert.lengthOf($selected, 0, name + ': nothing checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-
-          value = 'd';
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.equal(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 1, name + ': 1 checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-          assert.equal($checked.val(), value, name + ': model value correct');
-
-          value = '123';
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 1, name + ': 1 checked');
-          assert.lengthOf($other, 1, name + ': other box present');
-          assert.equal($other.val(), '123', name + ': other box shows "123"');
-          assert.equal($checked.val(), 'other', name + ': model value correct');
-
-          element.val('');
-          $other = $view.find('input[type=text]');
-          assert.notOk(element.val(), name + ': model value is falsey');
-          // assert.lengthOf($selected, 0, name + ': nothing checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-
-          if (element.get('nativeMenu')) {
-            assert.equal($view.find('select').data("role"), "none", name + ': data-role is not none');
-          } else {
-            assert.notEqual($view.find('select').data("role"), "none", name + ': data-role is not none');
-          }
-        });
-      });
-
-      test('multi+other bindings between model and "other" input', function () {
-        var form = Forms.current;
-        multiWithOther.forEach(function (name) {
-          var value;
-          var element = form.getElement(name);
-          var $view = element.get('_view').$el;
-          var $other;
-          var $checked;
-
-          element.val('');
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.notOk(element.val(), name + ': model value is falsey');
-          assert.lengthOf($checked, 0, name + ': nothing checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-
-          value = ['d'];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 1, name + ': 1 checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-          assert.deepEqual($checked.map(function () {
-            return $(this).val();
-          }).get(), value, name + ': model value correct');
-
-          value = ['d', 'e'];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 2, name + ': 2 checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-          assert.deepEqual($checked.map(function () {
-            return $(this).val();
-          }).get(), value, name + ': model value correct');
-
-          value = [''];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 1, name + ': 1 checked');
-          assert.lengthOf($other, 1, name + ': other box present');
-          assert.equal($other.val(), '', name + ': other box empty');
-
-          value = ['d', ''];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 2, name + ': 2 checked');
-          assert.lengthOf($other, 1, name + ': other box present');
-          assert.equal($other.val(), '', name + ': other box empty');
-          assert.deepEqual($checked.map(function () {
-            return $(this).val();
-          }).get(), ['d', 'other'], name + ': model value correct');
-
-          value = ['123'];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 1, name + ': 1 checked');
-          assert.lengthOf($other, 1, name + ': other box present');
-          assert.equal($other.val(), '123', name + ': other box shows "123"');
-          assert.deepEqual($checked.map(function () {
-            return $(this).val();
-          }).get(), ['other'], name + ': model value correct');
-
-          value = ['d', '123'];
-          element.val(value);
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.deepEqual(element.val(), value, name + ': model value correct');
-          assert.lengthOf($checked, 2, name + ': 2 checked');
-          assert.lengthOf($other, 1, name + ': other box present');
-          assert.equal($other.val(), '123', name + ': other box shows "123"');
-          assert.deepEqual($checked.map(function () {
-            return $(this).val();
-          }).get(), ['d', 'other'], name + ': model value correct');
-
-          element.val('');
-          $other = $view.find('input[type=text]');
-          $checked = $view.find(':checked');
-          assert.notOk(element.val(), name + ': model value is falsey');
-          assert.lengthOf($checked, 0, name + ': nothing checked');
-          assert.lengthOf($other, 0, name + ': other box absent');
-
-          if (element.get('nativeMenu')) {
-            assert.equal($view.find('select').data("role"), "none", name + ': data-role is not none');
-          } else {
-            assert.notEqual($view.find('select').data("role"), "none", name + ': data-role is not none');
-          }
-        });
-      });
-
-      test('FORMS-139 # select with values containing space', function () {
-        // UI -> API bindings
-        var form = Forms.current,
-          element = form.getElement('select_space'),
+          element = form.getElement(name),
+          options = Object.keys(element.get('options')),
           $fieldset = element.attributes._view.$el;
 
-        $fieldset.find('label:contains(Second)').trigger('click');
-        assert.equal(element.val(), 'Second', 'model.value = "Second"');
-        $fieldset.find('label:contains("First value")').trigger('click');
-        assert.equal(element.val(), 'First value', 'model.value = "First value"');
+        Promise.resolve()
+        .then(function () {
+          element.val('');
+          return testUtils.wait(500);
+        })
+        .then(function () {
+          assert.equal(element.val(), options[0], name + ': default value');
+          assert.equal($fieldset.find('.ui-btn-active').css('width'), '0px');
+
+          element.val(options[0]);
+          return testUtils.wait(500);
+        })
+        .then(function () {
+          assert.equal(element.val(), options[0], name + ': value=' + options[0]);
+          assert.equal($fieldset.find('.ui-btn-active').css('width'), '0px');
+
+          element.val(options[1]);
+          return testUtils.wait(500);
+        })
+        .then(function () {
+          assert.equal(element.val(), options[1], name + ': value=' + options[1]);
+          assert.notEqual($fieldset.find('.ui-btn-active').css('width'), '0px');
+        })
+        .then(done, done);
+
       });
 
-      test('FORMS-177 # BIC-JQM: Multiselect boxes don\'t always work as expected', function () {
+      test(name + ': view->model', function (done) {
         var form = Forms.current,
-          element = form.getElement('multiee'),
-          $fieldset = element.attributes._view.$el,
-          $a = $fieldset.find('a');
+          element = form.getElement(name),
+          options = Object.keys(element.get('options')),
+          $fieldset = element.attributes._view.$el;
 
-        assert.equal($a.length, 1);
+        Promise.resolve()
+        .then(function () {
+          element.val('');
+          return testUtils.wait(500);
+        })
+        .then(function () {
+          assert.equal(element.val(), options[0], name + ': default value');
+          assert.equal($fieldset.find('.ui-btn-active').css('width'), '0px');
 
-        $a.trigger('click');
+          $fieldset.find('div.ui-slider-switch').trigger('mousedown').trigger('mouseup').trigger('click');
+          return testUtils.wait(500);
+        })
+        .then(function () {
+          assert.equal(element.val(), options[1], name + ': value=' + options[1]);
+          assert.notEqual($fieldset.find('.ui-btn-active').css('width'), '0px');
 
-        assert.equal($('body').find($a.attr('href')).length, 1);
-      });
+          $fieldset.find('div.ui-slider-switch').trigger('mousedown').trigger('mouseup').trigger('click');
+          return testUtils.wait(500);
+        })
+        .then(function () {
+          assert.equal(element.val(), options[0], name + ': value=' + options[0]);
+          assert.equal($fieldset.find('.ui-btn-active').css('width'), '0px');
+        })
+        .then(done, done);
 
-      test('FORMS-179 # Radio button and check box groups sometimes contain an "Undefined" option', function () {
-        var form = Forms.current,
-          checkbox = form.getElement('Checkboxes'),
-          $chkEl = checkbox.attributes._view.$el,
-          radio = form.getElement('Radios'),
-          $radEl = radio.attributes._view.$el;
-
-        checkbox.set('value', ["test"]);
-        assert.equal($chkEl.find('input[type="text"]').length, 0, "textbox for checkboxes is visible");
-        radio.set('value', "test");
-        assert.equal($radEl.find('input[type="text"]').length, 0, "textbox for radios is visible");
-
-      });
-
-      suite('FORMS-206 # choice fields that are required but not-empty still block validation', function () {
-        var form,
-          element,
-          fields = {
-            'multicollapsedrequired': ["a"],
-            'multiexpandedrequired': ["a"],
-            'selectcollapsedrequired': "a",
-            'selectexpandedrequired': "a"
-          };
-
-        suiteSetup(function () {
-          form = Forms.current;
-        });
-
-        _.each(fields, function (v, k) {
-          test(k, function (done) {
-            element = form.getElement(k);
-            assert.equal(element.attributes._view.$el.children('ul').children('li').length, 1);
-            element.set('value', v);
-            assert.equal(element.attributes._view.$el.children('ul').children('li').length, 0);
-            element.set('value', null);
-            assert.equal(element.attributes._view.$el.children('ul').children('li').length, 1);
-            done();
-          });
-        });
-      });
-
-    }); // END: suite('Form', ...)
-
-    suite('change page', function () {
-
-      suiteSetup(function (done) {
-        choiceElements.forEach(function (name) {
-          var el = Forms.current.getElement(name);
-          if (el.get('type') === 'multi') {
-            el.val(['d']);
-          } else {
-            el.val('d');
-          }
-        });
-        Forms.current.getElement('boolean').val(1);
-        Forms.current.getElement('question').val('y');
-        setTimeout(function () {
-          Forms.current.get('pages').goto(1);
-          setTimeout(function () {
-            Forms.current.get('pages').goto(0);
-            done();
-          }, 497);
-        }, 497);
-      });
-
-      test('DOM reflects model value correctly', function () {
-        choiceElements.forEach(function (name) {
-          var el = Forms.current.getElement(name);
-          var el$ = el.get('_view').$el;
-          var input$;
-          if (el.get('mode') === 'collapsed') { // select
-            input$ = el$.find('select');
-          } else { // input[type=radio]
-            input$ = el$.find('input:checked');
-          }
-          assert.equal(input$.val(), 'd', name + '\'s DOM is up to date');
-        });
-      });
-
-      test('DOM reflects model value correctly: boolean', function () {
-        var el = Forms.current.getElement('boolean');
-        var select$ = el.get('_view').$el.find('select');
-        assert.equal(select$.val(), 1);
-      });
-
-      test('DOM reflects model value correctly: question', function () {
-        var el = Forms.current.getElement('question');
-        var select$ = el.get('_view').$el.find('select');
-        assert.equal(select$.val(), 'y');
-      });
-
-      test('all [data-role=fieldcontain] enhanced', function () {
-        var fieldcontain$ = $('[data-role=fieldcontain]');
-        var enhanced$ = $('[data-role=fieldcontain].ui-field-contain');
-        assert.equal(fieldcontain$.length, enhanced$.length);
-      });
-
-      test('all non-native fields should be jQM-enhanced', function () {
-        Forms.current.get('elements')
-        .where({ nativeMenu: false })
-        .forEach(function (el) {
-          var name = el.get('name');
-          var view$ = el.get('_view').$el;
-          var select$ = view$.find('select');
-          var enhSelect$ = select$.closest('.ui-select');
-          assert.equal(select$.length, enhSelect$.length, name + ': <select> enhanced');
-        });
       });
 
     });
 
-  }); // END: suite('1', ...)
+    ['selectc', 'multic', 'multif', 'multig', 'multiee'].forEach(function (name) {
+
+      test(name + ': model->view', function () {
+        var form = Forms.current,
+          element = form.getElement(name),
+          $el = element.attributes._view.$el;
+
+        if (element.attributes.type === 'multi') {
+          element.val(['b']);
+        } else {
+          element.val('b');
+        }
+        assert.equal($el.find('.ui-select .ui-btn-text').text(), 'beta');
+
+        element.val('');
+        if (element.attributes.type === 'multi') {
+          assert.equal($el.find('.ui-select .ui-btn-text').text(), 'select one or more...');
+        } else {
+          assert.equal($el.find('.ui-select .ui-btn-text').text(), 'select one...');
+        }
+      });
+
+      test(name + ': view->model', function () {
+        var form = Forms.current;
+        var element = form.getElement(name);
+        var $el = element.attributes._view.$el;
+        var $a = $el.children('.ui-select').find('[role=button]');
+        var $popup;
+        var $item;
+
+        $a.trigger('click');
+        $popup = $($a.attr('href'));
+        assert.lengthOf($popup, 1);
+
+        $item = $popup.find('[data-option-index=3]');
+        assert.equal($item.text().trim(), 'gamma');
+
+        $item.find('a').trigger('click');
+        if (element.attributes.type === 'multi') {
+          assert.deepEqual(element.val(), ['g']);
+        } else {
+          assert.equal(element.val(), 'g');
+        }
+      });
+    });
+
+    ['selectf', 'selecth'].forEach(function (name) {
+
+      test(name + ': model->view', function () {
+        var form = Forms.current,
+          element = form.getElement(name),
+          $el = element.attributes._view.$el;
+
+        element.val('b');
+        assert.equal($el.find('select').val(), 'b');
+
+        element.val('');
+        assert($el.find('select').val());
+      });
+
+      test(name + ': view->model', function () {
+        var form = Forms.current,
+          element = form.getElement(name),
+          $el = element.attributes._view.$el;
+
+        $el.find('select').val('g').trigger('change');
+        assert.equal(element.val(), 'g');
+      });
+
+    });
+
+    ['selecte', 'multie'].forEach(function (name) {
+
+      test(name + ': model->view', function () {
+        var form = Forms.current,
+          element = form.getElement(name),
+          $el = element.attributes._view.$el;
+
+        if (element.attributes.type === 'multi') {
+          element.val(['b']);
+          assert.equal($el.find('.ui-checkbox-on').text().trim(), 'beta');
+        } else {
+          element.val('b');
+          assert.equal($el.find('.ui-radio-on').text().trim(), 'beta');
+        }
+
+        if (element.attributes.type === 'multi') {
+          element.val([]);
+          assert.lengthOf($el.find('.ui-checkbox-on'), 0);
+        } else {
+          element.val('');
+          assert.lengthOf($el.find('.ui-radio-on'), 0);
+        }
+      });
+
+      test(name + ': view->model', function () {
+        var form = Forms.current,
+          element = form.getElement(name),
+          $el = element.attributes._view.$el;
+
+        if (element.attributes.type === 'multi') {
+          $el.find('.ui-checkbox').eq(2).children('label').trigger('click');
+          assert.deepEqual(element.val(), ['g']);
+        } else {
+          $el.find('.ui-radio').eq(2).children('label').trigger('click');
+          assert.equal(element.val(), 'g');
+        }
+      });
+
+    });
+
+    test('elements have original a|b|g options', function () {
+      var form = Forms.current;
+      choiceElements.forEach(function (name) {
+        var element = form.getElement(name);
+        var currentOptions = element.get('options');
+        assert.deepEqual(currentOptions, originalOptions, name + ' ' + JSON.stringify(currentOptions));
+      });
+    });
+
+    test('elements set to d|e|z options', function () {
+      var form = Forms.current;
+      choiceElements.forEach(function (name) {
+        var element = form.getElement(name);
+        // var currentOptions = element.get('options');
+        element.set('options', newOptions);
+      });
+    });
+
+    test('select+other bindings between model and "other" input', function () {
+      var form = Forms.current;
+      selectWithOther.forEach(function (name) {
+        var value;
+        var element = form.getElement(name);
+        var $view = element.get('_view').$el;
+        var $other;
+        var $checked;
+
+        element.val('');
+        $other = $view.find('input[type=text]');
+        assert.notOk(element.val(), name + ': model value is falsey');
+        // assert.lengthOf($selected, 0, name + ': nothing checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+
+        value = 'd';
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.equal(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 1, name + ': 1 checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+        assert.equal($checked.val(), value, name + ': model value correct');
+
+        value = '123';
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 1, name + ': 1 checked');
+        assert.lengthOf($other, 1, name + ': other box present');
+        assert.equal($other.val(), '123', name + ': other box shows "123"');
+        assert.equal($checked.val(), 'other', name + ': model value correct');
+
+        element.val('');
+        $other = $view.find('input[type=text]');
+        assert.notOk(element.val(), name + ': model value is falsey');
+        // assert.lengthOf($selected, 0, name + ': nothing checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+
+        if (element.get('nativeMenu')) {
+          assert.equal($view.find('select').data("role"), "none", name + ': data-role is not none');
+        } else {
+          assert.notEqual($view.find('select').data("role"), "none", name + ': data-role is not none');
+        }
+      });
+    });
+
+    test('multi+other bindings between model and "other" input', function () {
+      var form = Forms.current;
+      multiWithOther.forEach(function (name) {
+        var value;
+        var element = form.getElement(name);
+        var $view = element.get('_view').$el;
+        var $other;
+        var $checked;
+
+        element.val('');
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.notOk(element.val(), name + ': model value is falsey');
+        assert.lengthOf($checked, 0, name + ': nothing checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+
+        value = ['d'];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 1, name + ': 1 checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+        assert.deepEqual($checked.map(function () {
+          return $(this).val();
+        }).get(), value, name + ': model value correct');
+
+        value = ['d', 'e'];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 2, name + ': 2 checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+        assert.deepEqual($checked.map(function () {
+          return $(this).val();
+        }).get(), value, name + ': model value correct');
+
+        value = [''];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 1, name + ': 1 checked');
+        assert.lengthOf($other, 1, name + ': other box present');
+        assert.equal($other.val(), '', name + ': other box empty');
+
+        value = ['d', ''];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 2, name + ': 2 checked');
+        assert.lengthOf($other, 1, name + ': other box present');
+        assert.equal($other.val(), '', name + ': other box empty');
+        assert.deepEqual($checked.map(function () {
+          return $(this).val();
+        }).get(), ['d', 'other'], name + ': model value correct');
+
+        value = ['123'];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 1, name + ': 1 checked');
+        assert.lengthOf($other, 1, name + ': other box present');
+        assert.equal($other.val(), '123', name + ': other box shows "123"');
+        assert.deepEqual($checked.map(function () {
+          return $(this).val();
+        }).get(), ['other'], name + ': model value correct');
+
+        value = ['d', '123'];
+        element.val(value);
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.deepEqual(element.val(), value, name + ': model value correct');
+        assert.lengthOf($checked, 2, name + ': 2 checked');
+        assert.lengthOf($other, 1, name + ': other box present');
+        assert.equal($other.val(), '123', name + ': other box shows "123"');
+        assert.deepEqual($checked.map(function () {
+          return $(this).val();
+        }).get(), ['d', 'other'], name + ': model value correct');
+
+        element.val('');
+        $other = $view.find('input[type=text]');
+        $checked = $view.find(':checked');
+        assert.notOk(element.val(), name + ': model value is falsey');
+        assert.lengthOf($checked, 0, name + ': nothing checked');
+        assert.lengthOf($other, 0, name + ': other box absent');
+
+        if (element.get('nativeMenu')) {
+          assert.equal($view.find('select').data("role"), "none", name + ': data-role is not none');
+        } else {
+          assert.notEqual($view.find('select').data("role"), "none", name + ': data-role is not none');
+        }
+      });
+    });
+
+    test('FORMS-139 # select with values containing space', function () {
+      // UI -> API bindings
+      var form = Forms.current,
+        element = form.getElement('select_space'),
+        $fieldset = element.attributes._view.$el;
+
+      $fieldset.find('label:contains(Second)').trigger('click');
+      assert.equal(element.val(), 'Second', 'model.value = "Second"');
+      $fieldset.find('label:contains("First value")').trigger('click');
+      assert.equal(element.val(), 'First value', 'model.value = "First value"');
+    });
+
+    test('FORMS-177 # BIC-JQM: Multiselect boxes don\'t always work as expected', function () {
+      var form = Forms.current,
+        element = form.getElement('multiee'),
+        $fieldset = element.attributes._view.$el,
+        $a = $fieldset.find('a');
+
+      assert.equal($a.length, 1);
+
+      $a.trigger('click');
+
+      assert.equal($('body').find($a.attr('href')).length, 1);
+    });
+
+    test('FORMS-179 # Radio button and check box groups sometimes contain an "Undefined" option', function () {
+      var form = Forms.current,
+        checkbox = form.getElement('Checkboxes'),
+        $chkEl = checkbox.attributes._view.$el,
+        radio = form.getElement('Radios'),
+        $radEl = radio.attributes._view.$el;
+
+      checkbox.set('value', ["test"]);
+      assert.equal($chkEl.find('input[type="text"]').length, 0, "textbox for checkboxes is visible");
+      radio.set('value', "test");
+      assert.equal($radEl.find('input[type="text"]').length, 0, "textbox for radios is visible");
+
+    });
+
+    suite('FORMS-206 # choice fields that are required but not-empty still block validation', function () {
+      var form,
+        element,
+        fields = {
+          'multicollapsedrequired': ["a"],
+          'multiexpandedrequired': ["a"],
+          'selectcollapsedrequired': "a",
+          'selectexpandedrequired': "a"
+        };
+
+      suiteSetup(function () {
+        form = Forms.current;
+      });
+
+      _.each(fields, function (v, k) {
+        test(k, function (done) {
+          element = form.getElement(k);
+          assert.equal(element.attributes._view.$el.children('ul').children('li').length, 1);
+          element.set('value', v);
+          assert.equal(element.attributes._view.$el.children('ul').children('li').length, 0);
+          element.set('value', null);
+          assert.equal(element.attributes._view.$el.children('ul').children('li').length, 1);
+          done();
+        });
+      });
+    });
+
+  }); // END: suite('Form', ...)
+
+  suite('change page', function () {
+
+    suiteSetup(function (done) {
+      choiceElements.forEach(function (name) {
+        var el = Forms.current.getElement(name);
+        if (el.get('type') === 'multi') {
+          el.val(['d']);
+        } else {
+          el.val('d');
+        }
+      });
+      Forms.current.getElement('boolean').val(1);
+      Forms.current.getElement('question').val('y');
+      setTimeout(function () {
+        Forms.current.get('pages').goto(1);
+        setTimeout(function () {
+          Forms.current.get('pages').goto(0);
+          done();
+        }, 497);
+      }, 497);
+    });
+
+    test('DOM reflects model value correctly', function () {
+      choiceElements.forEach(function (name) {
+        var el = Forms.current.getElement(name);
+        var el$ = el.get('_view').$el;
+        var input$;
+        if (el.get('mode') === 'collapsed') { // select
+          input$ = el$.find('select');
+        } else { // input[type=radio]
+          input$ = el$.find('input:checked');
+        }
+        assert.equal(input$.val(), 'd', name + '\'s DOM is up to date');
+      });
+    });
+
+    test('DOM reflects model value correctly: boolean', function () {
+      var el = Forms.current.getElement('boolean');
+      var select$ = el.get('_view').$el.find('select');
+      assert.equal(select$.val(), 1);
+    });
+
+    test('DOM reflects model value correctly: question', function () {
+      var el = Forms.current.getElement('question');
+      var select$ = el.get('_view').$el.find('select');
+      assert.equal(select$.val(), 'y');
+    });
+
+    test('all [data-role=fieldcontain] enhanced', function () {
+      var fieldcontain$ = $('[data-role=fieldcontain]');
+      var enhanced$ = $('[data-role=fieldcontain].ui-field-contain');
+      assert.equal(fieldcontain$.length, enhanced$.length);
+    });
+
+    test('all non-native fields should be jQM-enhanced', function () {
+      Forms.current.get('elements')
+      .where({ nativeMenu: false })
+      .forEach(function (el) {
+        var name = el.get('name');
+        var view$ = el.get('_view').$el;
+        var select$ = view$.find('select');
+        var enhSelect$ = select$.closest('.ui-select');
+        assert.equal(select$.length, enhSelect$.length, name + ': <select> enhanced');
+      });
+    });
+
+  });
 
 });
 

--- a/test/2_choices/test.js
+++ b/test/2_choices/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'underscore', 'BIC'], function (Forms, testUtils, _) {
+define(['BlinkForms', 'testUtils', 'underscore'], function (Forms, testUtils, _) {
 
   var originalOptions = { a: 'alpha', b: 'beta', g: 'gamma' };
   var newOptions = { d: 'delta', e: 'epsilon', z: 'zeta' };

--- a/test/30_Subforms_inside_subforms/test.js
+++ b/test/30_Subforms_inside_subforms/test.js
@@ -1,24 +1,12 @@
-define(['BlinkForms', 'BIC'], function (Forms) {
+define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
   suite('30: Subforms inside Subforms', function () {
-    var $page = $('[data-role=page]');
-    var $content = $page.find('[data-role=content]');
 
     setup(function () {
-      return Forms.getDefinition('firstLevel', 'add').then(function (def) {
-        Forms.initialize(def);
-        $content.append(Forms.current.$form);
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
+      return testUtils.loadForm('firstLevel', 'add')
+      .then(function () {
         $(window).scrollTop(0);
       });
-    });
-
-    teardown(function () {
-      Forms.current.off();
-      $content.empty();
-      delete Forms.current;
     });
 
     test('Top Level elements collection returns 1 sub form', function () {

--- a/test/30_Subforms_inside_subforms/test.js
+++ b/test/30_Subforms_inside_subforms/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   suite('30: Subforms inside Subforms', function () {
 

--- a/test/31_2_conditional_logic_in_subforms/test.js
+++ b/test/31_2_conditional_logic_in_subforms/test.js
@@ -1,28 +1,13 @@
-define(['BlinkForms', 'BIC'], function (Forms) {
+define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+
+  testUtils.defineFormLoadSuite('firstLevel', 'add');
 
   suite('31.2 confirm that behaviour runs multiple times', function () {
-    var $page, $content, i;
-    suiteSetup(function () {
-      /* eslint-disable no-unused-expressions */
-      Forms.current && Forms.current.off();
-      delete Forms.current;
-      $content && $content.empty();
-      /* eslint-enable no-unused-expressions */
-
-      $page = $('[data-role=page]');
-      $content = $page.find('[data-role=content]');
-
-      return Forms.getDefinition('firstLevel', 'add').then(function (def) {
-        Forms.initialize(def);
-
-        $content.append(Forms.current.$form);
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-    });
 
     suite('second_level_field', function () {
+
+      var i;
+
       suiteSetup(function (done) {
         var form;
         var element;

--- a/test/31_2_conditional_logic_in_subforms/test.js
+++ b/test/31_2_conditional_logic_in_subforms/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('firstLevel', 'add');
 

--- a/test/31_conditional_logic_in_subforms/test.js
+++ b/test/31_conditional_logic_in_subforms/test.js
@@ -1,40 +1,13 @@
-define(['BlinkForms', 'BIC'], function (Forms) {
+define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
   suite('31: Conditional logic in sub forms', function () {
-    var $page, $content, form;
+    var form;
 
     setup(function () {
-      /* eslint-disable no-unused-expressions */
-      Forms.current && Forms.current.off();
-      delete Forms.current;
-      $content && $content.empty();
-      /* eslint-enable no-unused-expressions */
-      $page = undefined;
-      $content = undefined;
-      form = undefined;
-
-      $page = $('[data-role=page]');
-      $content = $page.find('[data-role=content]');
-
-      return Forms.getDefinition('firstLevel', 'add').then(function (def) {
-        Forms.initialize(def);
+      return testUtils.loadForm('firstLevel', 'add')
+      .then(function () {
         form = Forms.current;
-
-        $content.append(Forms.current.$form);
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
       });
-    });
-
-    teardown(function () {
-      // Forms.current.off();
-      // $content.empty();
-      // delete Forms.current;
-
-      // $page = undefined;
-      // $content = undefined;
-      // form = undefined;
     });
 
     suite('required fields', function () {

--- a/test/31_conditional_logic_in_subforms/test.js
+++ b/test/31_conditional_logic_in_subforms/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   suite('31: Conditional logic in sub forms', function () {
     var form;

--- a/test/31_subforms_collapse/test.js
+++ b/test/31_subforms_collapse/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   suite('31: subForms', function () {
 

--- a/test/31_subforms_collapse/test.js
+++ b/test/31_subforms_collapse/test.js
@@ -1,25 +1,10 @@
-/* global assert */ // chai
+define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
-define(['BlinkForms', 'BIC'], function (Forms) {
   suite('31: subForms', function () {
-    var $page = $('[data-role=page]');
-    var $content = $page.find('[data-role=content]');
-
-    var form;
 
     suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-      return Forms.getDefinition('form1', 'add').then(function (def) {
-        Forms.initialize(def, 'add');
-        form = Forms.current;
-
-        $content.append(form.$form);
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-
-        return Forms;
+      return testUtils.loadForm('form1', 'add')
+      .then(function () {
       });
     });
 

--- a/test/32_pristine_and_dirty/test.js
+++ b/test/32_pristine_and_dirty/test.js
@@ -1,11 +1,6 @@
-/* eslint-env mocha */
-/* global assert */ // chai
-
-define(['BlinkForms', 'BIC'], function (Forms) {
+define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
   suite('32 - Pristine and dirty states', function () {
-    var $page = $('[data-role=page]'),
-        $content = $page.find('[data-role=content]');
 
     var elementNames = [
       'text_area',
@@ -38,13 +33,8 @@ define(['BlinkForms', 'BIC'], function (Forms) {
     suite('#setPristine', function () {
       // make sure that the form is in a pristine state for each test.
       suiteSetup(function () {
-        $content.empty();
-        return Forms.getDefinition('every_field_type', 'add').then(function (def) {
-          Forms.initialize(def);
-          $content.append(Forms.current.$form);
-          $.mobile.page({}, $page);
-          $page.trigger('pagecreate');
-          $page.show();
+        return testUtils.loadForm('every_field_type', 'add')
+        .then(function () {
           $(window).scrollTop(0);
         });
       });
@@ -79,13 +69,8 @@ define(['BlinkForms', 'BIC'], function (Forms) {
 
     suite('Default Value', function () {
       suiteSetup(function () {
-        $content.empty();
-        return Forms.getDefinition('every_field_type', 'add').then(function (def) {
-          Forms.initialize(def);
-          $content.append(Forms.current.$form);
-          $.mobile.page({}, $page);
-          $page.trigger('pagecreate');
-          $page.show();
+        return testUtils.loadForm('every_field_type', 'add')
+        .then(function () {
           $(window).scrollTop(0);
         });
       });
@@ -105,13 +90,8 @@ define(['BlinkForms', 'BIC'], function (Forms) {
     suite('Fields that use the value attribute', function () {
       // make sure that the form is in a pristine state for each test.
       suiteSetup(function () {
-        $content.empty();
-        return Forms.getDefinition('every_field_type', 'add').then(function (def) {
-          Forms.initialize(def);
-          $content.append(Forms.current.$form);
-          $.mobile.page({}, $page);
-          $page.trigger('pagecreate');
-          $page.show();
+        return testUtils.loadForm('every_field_type', 'add')
+        .then(function () {
           $(window).scrollTop(0);
         });
       });
@@ -141,16 +121,11 @@ define(['BlinkForms', 'BIC'], function (Forms) {
     });
 
     suite('elements that use the blob attribute', function () {
+
       suiteSetup(function () {
-        $content.empty();
-        return Forms.getDefinition('every_field_type', 'add').then(function (def) {
-          Forms.initialize(def);
-          $content.append(Forms.current.$form);
-          $.mobile.page({}, $page);
-          $page.trigger('pagecreate');
-          $page.show();
+        return testUtils.loadForm('every_field_type', 'add')
+        .then(function () {
           $(window).scrollTop(0);
-        }).then(function () {
           return Forms.current.get('pages').goto(1);
         });
       });
@@ -170,16 +145,11 @@ define(['BlinkForms', 'BIC'], function (Forms) {
     });
 
     suite('elements in subforms', function () {
+
       suiteSetup(function () {
-        $content.empty();
-        return Forms.getDefinition('every_field_type', 'add').then(function (def) {
-          Forms.initialize(def);
-          $content.append(Forms.current.$form);
-          $.mobile.page({}, $page);
-          $page.trigger('pagecreate');
-          $page.show();
+        return testUtils.loadForm('every_field_type', 'add')
+        .then(function () {
           $(window).scrollTop(0);
-        }).then(function () {
           Forms.current.get('pages').goto(1);
 
           // add a subform
@@ -214,4 +184,3 @@ define(['BlinkForms', 'BIC'], function (Forms) {
     });
   });
 });
-

--- a/test/32_pristine_and_dirty/test.js
+++ b/test/32_pristine_and_dirty/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   suite('32 - Pristine and dirty states', function () {
 

--- a/test/33_pages_with_subforms/test.js
+++ b/test/33_pages_with_subforms/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   suite('33: Pages with subforms', function () {
     var form;

--- a/test/33_pages_with_subforms/test.js
+++ b/test/33_pages_with_subforms/test.js
@@ -1,7 +1,7 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
   suite('33: Pages with subforms', function () {
-    var $page, $content, form;
+    var form;
 
     var gotoPage = function (page) {
       form.get('pages').goto(page);
@@ -34,28 +34,11 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
       'get_value-comment'];
 
     suite('changing pages shouldnt remove labels', function () {
+
       suiteSetup(function () {
-        /* eslint-disable no-unused-expressions*/
-        Forms.current && Forms.current.off();
-        delete Forms.current;
-        $content && $content.empty();
-        /* eslint-enable no-unused-expressions*/
-        $page = undefined;
-        $content = undefined;
-        form = undefined;
-
-        $page = $('[data-role=page]');
-        $content = $page.find('[data-role=content]');
-
-        return Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
+        return testUtils.loadForm('form1', 'add')
+        .then(function () {
           form = Forms.current;
-
-          $content.append(Forms.current.$form);
-          $.mobile.page({}, $page);
-          $page.trigger('pagecreate');
-          $page.show();
-
           gotoPage(1);
           return Forms.current.getElement('comments').add();
         });
@@ -92,17 +75,9 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
         testUtils.defineButtonTest();
 
       });
+
     });
 
-    // suiteTeardown(function () {
-    //   Forms.current.off();
-    //   $content.empty();
-    //   delete Forms.current;
-
-    //   $page = undefined;
-    //   $content = undefined;
-    //   form = undefined;
-    // });
-
   });
+
 });

--- a/test/3_text_number_message/test.js
+++ b/test/3_text_number_message/test.js
@@ -1,213 +1,166 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
+  testUtils.defineFormLoadSuite('form1', 'add');
+
   suite('3: text/number/message', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+    test('no label gives full width output', function () {
+      var form = BMP.Forms.current,
+        element = form.getElement('message'),
+        view = element.attributes._view;
+
+      assert.lengthOf(view.$el.children('label'), 0);
+      assert.lengthOf(view.$el.children('div'), 0);
     });
 
-    suite('Form', function () {
+    test('label set displays like an input formElement', function () {
+      var form = BMP.Forms.current,
+        element = form.getElement('calculation'),
+        view = element.attributes._view;
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
+      assert.lengthOf(view.$el.children('label'), 1);
+      assert.lengthOf(view.$el.children('div'), 1);
+    });
+
+  }); // END: suite('Form', ...)
+
+  suite('placeholder', function () {
+
+    test('placeholderText settings are set in attributes', function () {
+      var form, elements;
+      form = BMP.Forms.current;
+      elements = form.get('elements');
+      elements.each(function (element) {
+        var placeholder, el$, input$, name;
+        name = element.get('name');
+        placeholder = element.get('placeholderText');
+        if (placeholder !== undefined && name !== 'number2') {
+          // TODO: fix tests for number sliders
+          el$ = element.get('_view').$el;
+          input$ = el$.find('[placeholder="' + placeholder + '"]');
+          assert.lengthOf(input$, 1, name + ' has placeholder');
+        }
       });
+    });
 
-      test('initialise with form.json', function (done) {
-        var form;
+  }); // END: suite('Form', ...)
 
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
+  suite('hidden', function () {
 
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
+    test('hidden field is actually hidden', function (done) {
+      var form = BMP.Forms.current,
+        element = form.getElement('hiddentext'),
+        view = element.attributes._view;
 
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-    }); // END: suite('Form', ...)
-
-    suite('Message', function () {
-
-      test('no label gives full width output', function () {
-        var form = BMP.Forms.current,
-          element = form.getElement('message'),
-          view = element.attributes._view;
-
-        assert.lengthOf(view.$el.children('label'), 0);
-        assert.lengthOf(view.$el.children('div'), 0);
-      });
-
-      test('label set displays like an input formElement', function () {
-        var form = BMP.Forms.current,
-          element = form.getElement('calculation'),
-          view = element.attributes._view;
-
-        assert.lengthOf(view.$el.children('label'), 1);
-        assert.lengthOf(view.$el.children('div'), 1);
-      });
-
-    }); // END: suite('Form', ...)
-
-    suite('placeholder', function () {
-
-      test('placeholderText settings are set in attributes', function () {
-        var form, elements;
-        form = BMP.Forms.current;
-        elements = form.get('elements');
-        elements.each(function (element) {
-          var placeholder, el$, input$, name;
-          name = element.get('name');
-          placeholder = element.get('placeholderText');
-          if (placeholder !== undefined && name !== 'number2') {
-            // TODO: fix tests for number sliders
-            el$ = element.get('_view').$el;
-            input$ = el$.find('[placeholder="' + placeholder + '"]');
-            assert.lengthOf(input$, 1, name + ' has placeholder');
-          }
-        });
-      });
-
-    }); // END: suite('Form', ...)
-
-    suite('hidden', function () {
-
-      test('hidden field is actually hidden', function (done) {
-        var form = BMP.Forms.current,
-          element = form.getElement('hiddentext'),
-          view = element.attributes._view;
-
-        assert(view.$el.attr('style'), 'display: none; ', 'field is not hidden');
-        form.data().then(function (data) {
-          assert.equal(data.hiddentext, "Test", "mismatch hidden field value");
-          done();
-        });
-
-      });
-
-      test('type=hidden field has no view', function () {
-        var form = BMP.Forms.current,
-          element = form.getElement('id'),
-          view = element.attributes._view;
-
-        assert(!view);
-        assert.lengthOf($('input[name=id]'), 0);
-
-      });
-
-    }); // END: suite('Form', ...)
-
-    suite('number', function () {
-
-      var fields = [
-        'number',
-        'number2'
-      ];
-
-      fields.forEach(function (name) {
-
-        test(name + ' field', function (done) {
-          var form = BMP.Forms.current,
-            element = form.getElement(name),
-            view = element.get('_view').$el,
-            attr = element.attributes;
-
-          if (attr.useSlider && attr.min && attr.max) {
-            assert.equal('range', view.find('input').attr('type'), name + " is not range field");
-          } else {
-            assert.equal('number', view.find('input').attr('type'), name + " is not number field");
-          }
-          done();
-        });
-
-      });
-
-      test('FORMS-161 # Have number fields default to empty', function () {
-        var form = Forms.current,
-          element = form.getElement('number3');
-
-        assert(element.attributes.defaultValue === "", "number3: defaultValue is not empty");
-        assert(element.get('value') === "", "element value is " + element.get('value'));
-
+      assert(view.$el.attr('style'), 'display: none; ', 'field is not hidden');
+      form.data().then(function (data) {
+        assert.equal(data.hiddentext, "Test", "mismatch hidden field value");
+        done();
       });
 
     });
 
-    suite('headings', function () {
+    test('type=hidden field has no view', function () {
+      var form = BMP.Forms.current,
+        element = form.getElement('id'),
+        view = element.attributes._view;
 
-      test('1st heading is an h1', function () {
-        var form, element, view;
-        form = BMP.Forms.current;
-        element = form.getElement('heading');
-        view = element.get('_view');
-        assert.lengthOf(view.$el, 1);
-        assert.equal(view.$el[0].nodeName, 'HEADER');
-        assert.equal(view.$el.children().length, 1);
-        assert.equal(view.$el.find('H1').length, 1);
-        assert.equal(view.$el.find('p').length, 0);
-      });
+      assert(!view);
+      assert.lengthOf($('input[name=id]'), 0);
 
-      test('2nd heading is an h2', function () {
-        var form, element, view;
-        form = BMP.Forms.current;
-        element = form.getElement('heading2');
-        view = element.get('_view');
-
-        assert.lengthOf(view.$el, 1);
-        assert.equal(view.$el[0].nodeName, 'HEADER');
-        assert.equal(view.$el.children().length, 1);
-        assert.equal(view.$el.find('H2').length, 1);
-        assert.equal(view.$el.find('p').length, 0);
-      });
-
-      test('3rd heading is an h3', function () {
-        var form, element, view;
-        form = BMP.Forms.current;
-        element = form.getElement('heading3');
-        view = element.get('_view');
-
-        assert.lengthOf(view.$el, 1);
-        assert.equal(view.$el[0].nodeName, 'HEADER');
-        assert.equal(view.$el.children().length, 1);
-        assert.equal(view.$el.find('H3').length, 1);
-        assert.equal(view.$el.find('p').length, 0);
-      });
-
-      test('4th heading is an h3 with small text', function () {
-        var form, element, view;
-        form = BMP.Forms.current;
-        element = form.getElement('heading4');
-        view = element.get('_view');
-
-        assert.lengthOf(view.$el, 1);
-        assert.equal(view.$el[0].nodeName, 'HEADER');
-        assert.equal(view.$el.children().length, 2);
-        assert.equal(view.$el.find('H3').length, 1);
-        assert.equal(view.$el.find('p').length, 1);
-      });
     });
 
-  }); // END: suite('1', ...)
+  }); // END: suite('Form', ...)
+
+  suite('number', function () {
+
+    var fields = [
+      'number',
+      'number2'
+    ];
+
+    fields.forEach(function (name) {
+
+      test(name + ' field', function (done) {
+        var form = BMP.Forms.current,
+          element = form.getElement(name),
+          view = element.get('_view').$el,
+          attr = element.attributes;
+
+        if (attr.useSlider && attr.min && attr.max) {
+          assert.equal('range', view.find('input').attr('type'), name + " is not range field");
+        } else {
+          assert.equal('number', view.find('input').attr('type'), name + " is not number field");
+        }
+        done();
+      });
+
+    });
+
+    test('FORMS-161 # Have number fields default to empty', function () {
+      var form = Forms.current,
+        element = form.getElement('number3');
+
+      assert(element.attributes.defaultValue === "", "number3: defaultValue is not empty");
+      assert(element.get('value') === "", "element value is " + element.get('value'));
+
+    });
+
+  });
+
+  suite('headings', function () {
+
+    test('1st heading is an h1', function () {
+      var form, element, view;
+      form = BMP.Forms.current;
+      element = form.getElement('heading');
+      view = element.get('_view');
+      assert.lengthOf(view.$el, 1);
+      assert.equal(view.$el[0].nodeName, 'HEADER');
+      assert.equal(view.$el.children().length, 1);
+      assert.equal(view.$el.find('H1').length, 1);
+      assert.equal(view.$el.find('p').length, 0);
+    });
+
+    test('2nd heading is an h2', function () {
+      var form, element, view;
+      form = BMP.Forms.current;
+      element = form.getElement('heading2');
+      view = element.get('_view');
+
+      assert.lengthOf(view.$el, 1);
+      assert.equal(view.$el[0].nodeName, 'HEADER');
+      assert.equal(view.$el.children().length, 1);
+      assert.equal(view.$el.find('H2').length, 1);
+      assert.equal(view.$el.find('p').length, 0);
+    });
+
+    test('3rd heading is an h3', function () {
+      var form, element, view;
+      form = BMP.Forms.current;
+      element = form.getElement('heading3');
+      view = element.get('_view');
+
+      assert.lengthOf(view.$el, 1);
+      assert.equal(view.$el[0].nodeName, 'HEADER');
+      assert.equal(view.$el.children().length, 1);
+      assert.equal(view.$el.find('H3').length, 1);
+      assert.equal(view.$el.find('p').length, 0);
+    });
+
+    test('4th heading is an h3 with small text', function () {
+      var form, element, view;
+      form = BMP.Forms.current;
+      element = form.getElement('heading4');
+      view = element.get('_view');
+
+      assert.lengthOf(view.$el, 1);
+      assert.equal(view.$el[0].nodeName, 'HEADER');
+      assert.equal(view.$el.children().length, 2);
+      assert.equal(view.$el.find('H3').length, 1);
+      assert.equal(view.$el.find('p').length, 1);
+    });
+
+  });
 
 });

--- a/test/3_text_number_message/test.js
+++ b/test/3_text_number_message/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('form1', 'add');
 

--- a/test/4_subforms/test.js
+++ b/test/4_subforms/test.js
@@ -1,67 +1,19 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+
   suite('4: subForms', function () {
-    var $doc = $(document),
-      $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
 
     var form;
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-    });
-
     setup(function () {
-      return Forms.getDefinition('form1', 'add').then(function (def) {
-        Forms.initialize(def, 'add');
+      return testUtils.loadForm('form1', 'add')
+      .then(function () {
         form = Forms.current;
-
-        $content.append(form.$form);
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-
-        return Forms;
       });
     });
 
     teardown(function () {
       form = null;
-      $content.empty();
-      delete Forms.current;
     });
-
-    suite('Form', function () {
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function () {
-        assert.equal($.type(form), 'object');
-        assert.equal(form.get('name'), 'form1');
-        assert.equal(form.get('label'), 'Form 1');
-      });
-
-      test('render form for jQuery Mobile', function (done) {
-        $content.empty().append(form.$form);
-
-        $doc.one('pageinit', function () {
-          form.attributes.preloadPromise.then(function () {
-            done();
-          });
-        });
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-    }); // END: suite('Form', ...)
 
 // ///////////////////////////////////////////////////////////////////////////////
 

--- a/test/4_subforms/test.js
+++ b/test/4_subforms/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   suite('4: subForms', function () {
 

--- a/test/5_validation/test.js
+++ b/test/5_validation/test.js
@@ -2,8 +2,7 @@ define([
   'underscore',
   'sinon',
   'BlinkForms',
-  'testUtils',
-  'BIC'
+  'testUtils'
 ], function (_, sinon, Forms, testUtils) {
 
   suite('i18n', function () {

--- a/test/5_validation/test.js
+++ b/test/5_validation/test.js
@@ -23,66 +23,23 @@ define([
   });
 
   suite('5: validation', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]'),
-      runTests = function (cases, element) {
-        var error;
+    var elements;
+    var runTests = function (cases, element) {
+      var error;
 
-        _.each(cases, function (v, i) {
-          element.val(v);
-          assert.isObject(element.validate(), 'now has a validation error');
-          assert.isArray(element.validate().value, 'something wrong with value');
-          error = _.find(element.validate().value, function (e) {
-            return _.isObject(e) && e.code === i;
-          });
-
-          assert.isObject(error, 'contained ' + i + ' error');
+      _.each(cases, function (v, i) {
+        element.val(v);
+        assert.isObject(element.validate(), 'now has a validation error');
+        assert.isArray(element.validate().value, 'something wrong with value');
+        error = _.find(element.validate().value, function (e) {
+          return _.isObject(e) && e.code === i;
         });
-      }, elements;
 
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-    });
-
-    suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
+        assert.isObject(error, 'contained ' + i + ' error');
       });
+    };
 
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function (done) {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-        form.attributes.preloadPromise.then(function () {
-          done();
-        });
-      });
-
-      testUtils.defineLabelTest();
-
-    }); // END: suite('Form', ...)
+    testUtils.defineFormLoadSuite('form1', 'add');
 
     suite('Validation', function () {
 

--- a/test/6_behaviours/test.js
+++ b/test/6_behaviours/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('form1', 'add');
 

--- a/test/6_behaviours/test.js
+++ b/test/6_behaviours/test.js
@@ -1,52 +1,8 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
+  testUtils.defineFormLoadSuite('form1', 'add');
+
   suite('6: automated behaviours', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
-
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
-    });
-
-    suite('Form', function () {
-
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-    }); // END: suite('Form', ...)
 
     suite('Message', function () {
 

--- a/test/7_population/test.js
+++ b/test/7_population/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('form1', 'add');
 

--- a/test/7_population/test.js
+++ b/test/7_population/test.js
@@ -1,68 +1,85 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
-  suite('7: record population', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('form1', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  suite('7: record population', function () {
+    var record = {
+      id: 'harry7',
+      name: 'Harry Potter',
+      comments: [
+        {
+          id: '1',
+          comment: 'what a whiner'
+        },
+        {
+          id: '2',
+          comment: 'get a comb'
+        }
+      ]
+    };
+
+    test('promise is resolved', function (done) {
+      Forms.current.setRecord(record).then(function () {
+        assert(true, 'success handler for promise called');
+        done();
+      });
     });
 
-    suite('Form', function () {
+    test('"name" element populated', function () {
+      var form = BMP.Forms.current;
+      assert.equal(form.getElement('name').val(), 'Harry Potter');
+    });
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
+    test('"id" element created and populated', function () {
+      var form = BMP.Forms.current;
+      assert.equal(form.getElement('id').val(), 'harry7');
+    });
+
+    test('"comments" has 2 subRecords', function () {
+      var form = BMP.Forms.current,
+        comments = form.getElement('comments');
+
+      assert.equal(comments.size(), 2);
+    });
+
+    test('"comment[0]" populated correctly', function () {
+      var form = BMP.Forms.current,
+        sub = form.getElement('comments').getForm(0),
+        comment = sub.getElement('comment');
+
+      assert.equal(comment.val(), 'what a whiner');
+    });
+
+    test('"comment[1]" populated correctly', function () {
+      var form = BMP.Forms.current,
+        sub = form.getElement('comments').getForm(1),
+        comment = sub.getElement('comment');
+
+      assert.equal(comment.val(), 'get a comb');
+    });
+
+    suite('comments.setRecords() with 3 subForms', function () {
+
+      suiteSetup(function () {
+        record = {
+          id: 'harry7',
+          name: 'Harry Potter',
+          comments: [
+            {
+              id: '1',
+              comment: 'what a whiner'
+            },
+            {
+              id: '2',
+              comment: 'get a comb'
+            },
+            {
+              id: '3',
+              comment: 'nice scar'
+            }
+          ]
+        };
       });
-
-      test('initialise with form.json', function (done) {
-        var form;
-
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-    }); // END: suite('Form', ...)
-
-    suite('form.setRecord() with 2 nested subForms', function () {
-      var record = {
-        id: 'harry7',
-        name: 'Harry Potter',
-        comments: [
-          {
-            id: '1',
-            comment: 'what a whiner'
-          },
-          {
-            id: '2',
-            comment: 'get a comb'
-          }
-        ]
-      };
 
       test('promise is resolved', function (done) {
         Forms.current.setRecord(record).then(function () {
@@ -71,21 +88,11 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
         });
       });
 
-      test('"name" element populated', function () {
-        var form = BMP.Forms.current;
-        assert.equal(form.getElement('name').val(), 'Harry Potter');
-      });
-
-      test('"id" element created and populated', function () {
-        var form = BMP.Forms.current;
-        assert.equal(form.getElement('id').val(), 'harry7');
-      });
-
-      test('"comments" has 2 subRecords', function () {
+      test('"comments" has 3 subRecords', function () {
         var form = BMP.Forms.current,
           comments = form.getElement('comments');
 
-        assert.equal(comments.size(), 2);
+        assert.equal(comments.size(), 3);
       });
 
       test('"comment[0]" populated correctly', function () {
@@ -104,109 +111,54 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
         assert.equal(comment.val(), 'get a comb');
       });
 
-      suite('comments.setRecords() with 3 subForms', function () {
+      test('"comment[2]" populated correctly', function () {
+        var form = BMP.Forms.current,
+          sub = form.getElement('comments').getForm(2),
+          comment = sub.getElement('comment');
 
-        suiteSetup(function () {
-          record = {
-            id: 'harry7',
-            name: 'Harry Potter',
-            comments: [
-              {
-                id: '1',
-                comment: 'what a whiner'
-              },
-              {
-                id: '2',
-                comment: 'get a comb'
-              },
-              {
-                id: '3',
-                comment: 'nice scar'
-              }
-            ]
-          };
+        assert.equal(comment.val(), 'nice scar');
+      });
+
+    }); // END: suite('comments.setRecord() with 3...', ...)
+
+    suite('comments.setRecords() with 1 subForms', function () {
+
+      suiteSetup(function () {
+        record = {
+          id: 'harry7',
+          name: 'Harry Potter',
+          comments: [
+            {
+              id: '3',
+              comment: 'nice scar'
+            }
+          ]
+        };
+      });
+
+      test('promise is resolved', function (done) {
+        Forms.current.setRecord(record).then(function () {
+          assert(true, 'success handler for promise called');
+          done();
         });
+      });
 
-        test('promise is resolved', function (done) {
-          Forms.current.setRecord(record).then(function () {
-            assert(true, 'success handler for promise called');
-            done();
-          });
-        });
+      test('"comments" has 1 subRecord', function () {
+        var form = BMP.Forms.current,
+          comments = form.getElement('comments');
 
-        test('"comments" has 3 subRecords', function () {
-          var form = BMP.Forms.current,
-            comments = form.getElement('comments');
+        assert.equal(comments.size(), 1);
+      });
 
-          assert.equal(comments.size(), 3);
-        });
+      test('"comment[0]" populated correctly', function () {
+        var form = BMP.Forms.current,
+          sub = form.getElement('comments').getForm(0),
+          comment = sub.getElement('comment');
 
-        test('"comment[0]" populated correctly', function () {
-          var form = BMP.Forms.current,
-            sub = form.getElement('comments').getForm(0),
-            comment = sub.getElement('comment');
+        assert.equal(comment.val(), 'nice scar');
+      });
+    }); // END: suite('comments.setRecord() with 3...', ...)
 
-          assert.equal(comment.val(), 'what a whiner');
-        });
-
-        test('"comment[1]" populated correctly', function () {
-          var form = BMP.Forms.current,
-            sub = form.getElement('comments').getForm(1),
-            comment = sub.getElement('comment');
-
-          assert.equal(comment.val(), 'get a comb');
-        });
-
-        test('"comment[2]" populated correctly', function () {
-          var form = BMP.Forms.current,
-            sub = form.getElement('comments').getForm(2),
-            comment = sub.getElement('comment');
-
-          assert.equal(comment.val(), 'nice scar');
-        });
-
-      }); // END: suite('comments.setRecord() with 3...', ...)
-
-      suite('comments.setRecords() with 1 subForms', function () {
-
-        suiteSetup(function () {
-          record = {
-            id: 'harry7',
-            name: 'Harry Potter',
-            comments: [
-              {
-                id: '3',
-                comment: 'nice scar'
-              }
-            ]
-          };
-        });
-
-        test('promise is resolved', function (done) {
-          Forms.current.setRecord(record).then(function () {
-            assert(true, 'success handler for promise called');
-            done();
-          });
-        });
-
-        test('"comments" has 1 subRecord', function () {
-          var form = BMP.Forms.current,
-            comments = form.getElement('comments');
-
-          assert.equal(comments.size(), 1);
-        });
-
-        test('"comment[0]" populated correctly', function () {
-          var form = BMP.Forms.current,
-            sub = form.getElement('comments').getForm(0),
-            comment = sub.getElement('comment');
-
-          assert.equal(comment.val(), 'nice scar');
-        });
-      }); // END: suite('comments.setRecord() with 3...', ...)
-
-    });
-
-  }); // END: suite('1', ...)
+  });
 
 });

--- a/test/8_blobs/test.js
+++ b/test/8_blobs/test.js
@@ -1,4 +1,4 @@
-define(['backbone', 'BlinkForms', 'testUtils', 'BIC'], function (Backbone, Forms, testUtils) {
+define(['backbone', 'BlinkForms', 'testUtils'], function (Backbone, Forms, testUtils) {
 
   var mockXhrUpload = new Backbone.Model();
   mockXhrUpload.addEventListener = function (type, handler) {

--- a/test/8_blobs/test.js
+++ b/test/8_blobs/test.js
@@ -18,184 +18,138 @@ define(['backbone', 'BlinkForms', 'testUtils', 'BIC'], function (Backbone, Forms
     }
   };
 
-  suite('8: blobs', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('form1', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  suite('8: blobs', function () {
+
+    test('location button is enabled', function (done) {
+      var form = Forms.current,
+        element = form.getElement('location'),
+        view = element.get('_view'),
+        button = view.$el.find('button');
+
+      element.once('change:value change:errors', function () {
+        setTimeout(function () {
+          assert.isFalse(button.hasClass('ui-disabled'));
+        }, 1000);
+      });
+
+      button.trigger('click');
+
+      setTimeout(function () {
+        $(document.body).find('[data-action=cancel]').trigger('click');
+        done();
+      }, 100);
     });
 
-    suite('Form', function () {
+    test('location button popup elements', function (done) {
+      var form = Forms.current,
+        element = form.getElement('location'),
+        view = element.get('_view'),
+        button = view.$el.find('button'),
+        $body;
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
-      });
+      button.trigger('click');
 
-      test('initialise with form.json', function (done) {
-        var form;
+      setTimeout(function () {
+        $body = $(document.body);
+        assert.lengthOf($body.find('[data-action=cancel]'), 1);
+        assert.lengthOf($body.find('[data-action=clear]'), 1);
+        assert.lengthOf($body.find('button[type="submit"]'), 1);
+        assert.lengthOf($body.find('#map-canvas'), 1);
+        assert.lengthOf($body.find('#bmp-forms-location'), 1);
+        $body.find('[data-action=cancel]').trigger('click');
+        done();
+      }, 100);
+    });
 
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          form.set('answerSpace', 'blah');
-          form.set('uuid', Forms.uuid.v4());
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
-      });
-
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
-
-        $content.append(form.$form);
-
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
-      });
-
-      testUtils.defineLabelTest();
-
-      test('location button is enabled', function (done) {
-        var form = Forms.current,
-          element = form.getElement('location'),
-          view = element.get('_view'),
-          button = view.$el.find('button');
-
-        element.once('change:value change:errors', function () {
-          setTimeout(function () {
-            assert.isFalse(button.hasClass('ui-disabled'));
-          }, 1000);
-        });
-
-        button.trigger('click');
-
-        setTimeout(function () {
-          $(document.body).find('[data-action=cancel]').trigger('click');
-          done();
-        }, 100);
-      });
-
-      test('location button popup elements', function (done) {
-        var form = Forms.current,
-          element = form.getElement('location'),
-          view = element.get('_view'),
-          button = view.$el.find('button'),
-          $body;
-
-        button.trigger('click');
-
-        setTimeout(function () {
-          $body = $(document.body);
-          assert.lengthOf($body.find('[data-action=cancel]'), 1);
-          assert.lengthOf($body.find('[data-action=clear]'), 1);
-          assert.lengthOf($body.find('button[type="submit"]'), 1);
-          assert.lengthOf($body.find('#map-canvas'), 1);
-          assert.lengthOf($body.find('#bmp-forms-location'), 1);
-          $body.find('[data-action=cancel]').trigger('click');
-          done();
-        }, 100);
-      });
-
-      test('form&isPopulating is true during form#setRecord()', function (done) {
-        var form = Forms.current;
+    test('form&isPopulating is true during form#setRecord()', function (done) {
+      var form = Forms.current;
+      assert.isFalse(form.get('isPopulating'));
+      form.setRecord({}).then(function () {
         assert.isFalse(form.get('isPopulating'));
-        form.setRecord({}).then(function () {
-          assert.isFalse(form.get('isPopulating'));
-          done();
-        }, function (err) {
-          assert.isFalse(form.get('isPopulating'));
-          assert.ok(false, 'Promise should not be rejected');
-          assert.notOk(err, 'Promise should not have an error');
-          done();
-        });
-        assert.isTrue(form.get('isPopulating'));
+        done();
+      }, function (err) {
+        assert.isFalse(form.get('isPopulating'));
+        assert.ok(false, 'Promise should not be rejected');
+        assert.notOk(err, 'Promise should not have an error');
+        done();
+      });
+      assert.isTrue(form.get('isPopulating'));
+    });
+
+    test('#setBlobFromString() accepts non-DataURI Base64', function () {
+      // var data = 'abc123';
+      var form = Forms.current;
+      // var element = form.getElement('file');
+      form.set('isPopulating', true);
+      assert.doesNotThrow(function () {
+        // element.setBlobFromString(data);
+      });
+      form.set('isPopulating', false);
+    });
+
+    suite('"required" validation', function () {
+      var reqEl;
+
+      suiteSetup(function (done) {
+        reqEl = Forms.current.getElement('file_r');
+        reqEl.val('');
+        setTimeout(done, 0);
       });
 
-      test('#setBlobFromString() accepts non-DataURI Base64', function () {
-        // var data = 'abc123';
-        var form = Forms.current;
-        // var element = form.getElement('file');
-        form.set('isPopulating', true);
+      test('#val("") fails validation', function () {
+        var errors;
+        reqEl.val('');
+        errors = reqEl.validate();
+        assert.isObject(errors);
+        assert.isArray(errors.value);
+        assert.lengthOf(errors.value, 1);
+        assert.deepEqual(errors.value[0], { code: 'REQUIRED' });
+      });
+
+      test('#val("...") passes validation', function () {
+        var errors;
+        reqEl.setBlobFromString('data:image/jpeg;base64,abc123');
+        errors = reqEl.validate();
+        assert(!errors);
+      });
+
+      test('#setBlobFromString("...") passes validation', function () {
+        var errors;
+        reqEl.val('data:image/jpeg;base64,abc123');
+        errors = reqEl.validate();
+        assert(!errors);
+      });
+
+    });
+
+    suite('#setBlobFromString()', function () {
+      var element;
+
+      setup(function () {
+        Forms.current.set('isPopulating', true);
+        element = Forms.current.getElement('file');
+      });
+
+      test('accepts DataURI with Base64', function () {
         assert.doesNotThrow(function () {
-          // element.setBlobFromString(data);
+          element.setBlobFromString('data:image/jpeg;base64,abc123');
         });
-        form.set('isPopulating', false);
       });
 
-      suite('"required" validation', function () {
-        var reqEl;
-
-        suiteSetup(function (done) {
-          reqEl = Forms.current.getElement('file_r');
-          reqEl.val('');
-          setTimeout(done, 0);
+      test('accepts non-DataURI Base64', function () {
+        assert.doesNotThrow(function () {
+          element.setBlobFromString('abc123');
         });
-
-        test('#val("") fails validation', function () {
-          var errors;
-          reqEl.val('');
-          errors = reqEl.validate();
-          assert.isObject(errors);
-          assert.isArray(errors.value);
-          assert.lengthOf(errors.value, 1);
-          assert.deepEqual(errors.value[0], { code: 'REQUIRED' });
-        });
-
-        test('#val("...") passes validation', function () {
-          var errors;
-          reqEl.setBlobFromString('data:image/jpeg;base64,abc123');
-          errors = reqEl.validate();
-          assert(!errors);
-        });
-
-        test('#setBlobFromString("...") passes validation', function () {
-          var errors;
-          reqEl.val('data:image/jpeg;base64,abc123');
-          errors = reqEl.validate();
-          assert(!errors);
-        });
-
       });
 
-      suite('#setBlobFromString()', function () {
-        var element;
-
-        setup(function () {
-          Forms.current.set('isPopulating', true);
-          element = Forms.current.getElement('file');
-        });
-
-        test('accepts DataURI with Base64', function () {
-          assert.doesNotThrow(function () {
-            element.setBlobFromString('data:image/jpeg;base64,abc123');
-          });
-        });
-
-        test('accepts non-DataURI Base64', function () {
-          assert.doesNotThrow(function () {
-            element.setBlobFromString('abc123');
-          });
-        });
-
-        teardown(function () {
-          Forms.current.set('isPopulating', true);
-        });
-
+      teardown(function () {
+        Forms.current.set('isPopulating', true);
       });
 
-    }); // END: suite('Form', ...)
+    });
 
-  }); // END: suite('1', ...)
+  }); // END: suite('Form', ...)
 
 });

--- a/test/9_pages/test.js
+++ b/test/9_pages/test.js
@@ -1,223 +1,175 @@
 define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
-  suite('9: pages', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+  testUtils.defineFormLoadSuite('form1', 'add');
 
-    /**
-     * execute once before everything else in this suite
-     */
-    suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+  suite('9: pages', function () {
+
+    test('starts at page 0', function () {
+      var form = Forms.current,
+        pages = form.attributes.pages,
+        page = pages.current;
+
+      assert.equal(page.index(), 0);
     });
 
-    suite('Form', function () {
+    test('page 0 elements are visible', function () {
+      var form = Forms.current,
+        names = ['url', 'email', 'password'];
 
-      test('BlinkForms global is an Object', function () {
-        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
+      names.forEach(function (name) {
+        var element = form.getElement(name),
+          view = element.get('_view');
+
+        assert.isTrue(view.$el.is(':visible'), name + ' is visible');
+      });
+    });
+
+    test('page 1,2 elements are not present', function () {
+      var form = Forms.current,
+        names = ['streetAddress', 'city', 'telephone', 'number', 'currency'];
+
+      names.forEach(function (name) {
+        var element = form.getElement(name),
+          view = element.get('_view');
+
+        assert(!view, name + ' is not present');
+      });
+    });
+
+    test('go to page 1, triggers event', function (done) {
+      var form = Forms.current,
+        pages = form.attributes.pages,
+        page;
+
+      Forms.once('pageInjected', function (p) {
+        page = pages.current;
+        assert.equal(page, p);
+        assert.equal(page.index(), 1);
+        done();
       });
 
-      test('initialise with form.json', function (done) {
-        var form;
+      pages.goto(1);
+    });
 
-        Forms.getDefinition('form1', 'add').then(function (def) {
-          Forms.initialize(def);
-          form = Forms.current;
-          assert.equal($.type(form), 'object');
-          assert.equal(form.get('name'), 'form1');
-          assert.equal(form.get('label'), 'Form 1');
-          done();
-        }, function () {
-          assert.fail(true, false, 'getDefinition failed!');
-          done();
-        });
+    test('page 1 elements are visible', function () {
+      var form = Forms.current,
+        names = ['streetAddress', 'city'];
+
+      names.forEach(function (name) {
+        var element = form.getElement(name),
+          view = element.get('_view');
+
+        assert.isTrue(view.$el.is(':visible'), name + ' is visible');
+      });
+    });
+
+    test('page 0,2 elements are not present', function () {
+      var form = Forms.current,
+        names = ['url', 'email', 'password', 'telephone', 'number',
+          'currency'];
+
+      names.forEach(function (name) {
+        var element = form.getElement(name),
+          view = element.get('_view');
+
+        assert(!view, name + ' is not present');
+      });
+    });
+
+    test('go to page 2, triggers event', function (done) {
+      var form = Forms.current,
+        pages = form.attributes.pages,
+        page;
+
+      Forms.once('pageInjected', function (p) {
+        page = pages.current;
+        assert.equal(page, p);
+        assert.equal(page.index(), 2);
+        done();
       });
 
-      test('render form for jQuery Mobile', function () {
-        var form = Forms.current;
+      pages.goto(2);
+    });
 
-        $content.append(form.$form);
+    test('page 2 elements are visible', function () {
+      var form = Forms.current,
+        names = ['telephone', 'number', 'currency'];
 
-        $.mobile.page({}, $page);
-        $page.trigger('pagecreate');
-        $page.show();
+      names.forEach(function (name) {
+        var element = form.getElement(name),
+          view = element.get('_view');
+
+        assert.isTrue(view.$el.is(':visible'), name + ' is visible');
       });
+    });
 
-      testUtils.defineLabelTest();
+    test('page 2 number slider is still slider', function () {
+      var form = Forms.current,
+        numberSlider = form.getElement('numberSlider'),
+        $input = numberSlider.attributes._view.$el.find('input'),
+        pages = form.attributes.pages;
 
-    }); // END: suite('Form', ...)
+      // ui-slider is rendered
+      assert(numberSlider.attributes._view.$el.find('div.ui-slider'));
 
-    suite('Pages', function () {
+      // input value is equal to model
+      assert.equal($input.val(), numberSlider.get('value'));
 
-      test('starts at page 0', function () {
-        var form = Forms.current,
-          pages = form.attributes.pages,
-          page = pages.current;
+      // set model value and should change input value
+      numberSlider.set("value", 100);
+      assert.equal($input.val(), numberSlider.get('value'));
 
-        assert.equal(page.index(), 0);
+      // set input value, and trigger change, should change model value
+      $input.val(200);
+      numberSlider.attributes._view.$el.trigger("change");
+      assert.equal($input.val(), numberSlider.get('value'));
+
+      // switch pages back and forth
+      pages.goto(1);
+      pages.goto(2);
+      // ui-slider should be on page
+      assert(numberSlider.attributes._view.$el.find('div.ui-slider'));
+      // model value should be the same
+      assert.equal(numberSlider.get('value'), 200);
+      // input value should be the same
+      assert.equal($input.val(), numberSlider.get('value'));
+
+    });
+
+    test('page 0,1 elements are not present', function () {
+      var form = Forms.current,
+        names = ['url', 'email', 'password', 'streetAddress', 'city'];
+
+      names.forEach(function (name) {
+        var element = form.getElement(name),
+          view = element.get('_view');
+
+        assert(!view, name + ' is not present');
       });
+    });
 
-      test('page 0 elements are visible', function () {
-        var form = Forms.current,
-          names = ['url', 'email', 'password'];
-
-        names.forEach(function (name) {
-          var element = form.getElement(name),
-            view = element.get('_view');
-
-          assert.isTrue(view.$el.is(':visible'), name + ' is visible');
-        });
+    test('BMP.Forms.current.data() returns everything', function (done) {
+      Forms.current.data().then(function (data) {
+        assert.equal(data.url, 'https://blinkm.co/ron');
+        assert.equal(data.email, 'ron@blinkmobile.com.au');
+        assert.equal(data.password, 'secret');
+        assert.equal(data.streetAddress, 'Suite 2\r\n125 Donnison Street');
+        assert.equal(data.city, 'Gosford');
+        assert.equal(data.telephone, '+61 439 901 787');
+        assert.equal(data.number, 35);
+        assert.equal(data.currency, 876.54);
+        done();
       });
+    });
 
-      test('page 1,2 elements are not present', function () {
-        var form = Forms.current,
-          names = ['streetAddress', 'city', 'telephone', 'number', 'currency'];
+    test('Forms.current.get("_view").goToElement() can goto fields on other pages', function () {
+      var previousPage = BMP.Forms.current.get('pages').current.cid;
+      Forms.current.get("_view").goToElement('email');
 
-        names.forEach(function (name) {
-          var element = form.getElement(name),
-            view = element.get('_view');
+      assert.notEqual(BMP.Forms.current.get('pages').current.cid, previousPage);
+      assert.isTrue($('[name="email"]').is(':visible'));
+    });
 
-          assert(!view, name + ' is not present');
-        });
-      });
-
-      test('go to page 1, triggers event', function (done) {
-        var form = Forms.current,
-          pages = form.attributes.pages,
-          page;
-
-        Forms.once('pageInjected', function (p) {
-          page = pages.current;
-          assert.equal(page, p);
-          assert.equal(page.index(), 1);
-          done();
-        });
-
-        pages.goto(1);
-      });
-
-      test('page 1 elements are visible', function () {
-        var form = Forms.current,
-          names = ['streetAddress', 'city'];
-
-        names.forEach(function (name) {
-          var element = form.getElement(name),
-            view = element.get('_view');
-
-          assert.isTrue(view.$el.is(':visible'), name + ' is visible');
-        });
-      });
-
-      test('page 0,2 elements are not present', function () {
-        var form = Forms.current,
-          names = ['url', 'email', 'password', 'telephone', 'number',
-            'currency'];
-
-        names.forEach(function (name) {
-          var element = form.getElement(name),
-            view = element.get('_view');
-
-          assert(!view, name + ' is not present');
-        });
-      });
-
-      test('go to page 2, triggers event', function (done) {
-        var form = Forms.current,
-          pages = form.attributes.pages,
-          page;
-
-        Forms.once('pageInjected', function (p) {
-          page = pages.current;
-          assert.equal(page, p);
-          assert.equal(page.index(), 2);
-          done();
-        });
-
-        pages.goto(2);
-      });
-
-      test('page 2 elements are visible', function () {
-        var form = Forms.current,
-          names = ['telephone', 'number', 'currency'];
-
-        names.forEach(function (name) {
-          var element = form.getElement(name),
-            view = element.get('_view');
-
-          assert.isTrue(view.$el.is(':visible'), name + ' is visible');
-        });
-      });
-
-      test('page 2 number slider is still slider', function () {
-        var form = Forms.current,
-          numberSlider = form.getElement('numberSlider'),
-          $input = numberSlider.attributes._view.$el.find('input'),
-          pages = form.attributes.pages;
-
-        // ui-slider is rendered
-        assert(numberSlider.attributes._view.$el.find('div.ui-slider'));
-
-        // input value is equal to model
-        assert.equal($input.val(), numberSlider.get('value'));
-
-        // set model value and should change input value
-        numberSlider.set("value", 100);
-        assert.equal($input.val(), numberSlider.get('value'));
-
-        // set input value, and trigger change, should change model value
-        $input.val(200);
-        numberSlider.attributes._view.$el.trigger("change");
-        assert.equal($input.val(), numberSlider.get('value'));
-
-        // switch pages back and forth
-        pages.goto(1);
-        pages.goto(2);
-        // ui-slider should be on page
-        assert(numberSlider.attributes._view.$el.find('div.ui-slider'));
-        // model value should be the same
-        assert.equal(numberSlider.get('value'), 200);
-        // input value should be the same
-        assert.equal($input.val(), numberSlider.get('value'));
-
-      });
-
-      test('page 0,1 elements are not present', function () {
-        var form = Forms.current,
-          names = ['url', 'email', 'password', 'streetAddress', 'city'];
-
-        names.forEach(function (name) {
-          var element = form.getElement(name),
-            view = element.get('_view');
-
-          assert(!view, name + ' is not present');
-        });
-      });
-
-      test('BMP.Forms.current.data() returns everything', function (done) {
-        Forms.current.data().then(function (data) {
-          assert.equal(data.url, 'https://blinkm.co/ron');
-          assert.equal(data.email, 'ron@blinkmobile.com.au');
-          assert.equal(data.password, 'secret');
-          assert.equal(data.streetAddress, 'Suite 2\r\n125 Donnison Street');
-          assert.equal(data.city, 'Gosford');
-          assert.equal(data.telephone, '+61 439 901 787');
-          assert.equal(data.number, 35);
-          assert.equal(data.currency, 876.54);
-          done();
-        });
-      });
-
-      test('Forms.current.get("_view").goToElement() can goto fields on other pages', function () {
-        var previousPage = BMP.Forms.current.get('pages').current.cid;
-        Forms.current.get("_view").goToElement('email');
-
-        assert.notEqual(BMP.Forms.current.get('pages').current.cid, previousPage);
-        assert.isTrue($('[name="email"]').is(':visible'));
-      });
-
-    }); // END: suite('Pages', ...)
-
-  }); // END: suite('1', ...)
+  }); // END: suite('Pages', ...)
 
 });

--- a/test/9_pages/test.js
+++ b/test/9_pages/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
   testUtils.defineFormLoadSuite('form1', 'add');
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,4 +1,5 @@
-define(['BlinkForms'], function (Forms) {
+// need the BIC module to set up `.getDefinition()`, etc
+define(['BlinkForms', 'BIC'], function (Forms) {
 
   var NO_LABELS = ['hidden', 'heading', 'message', 'subForm', 'button'];
   var CHOICES = ['select', 'multi']

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -12,6 +12,10 @@ define(['BlinkForms', 'BIC'], function (Forms) {
 
   var mod = {
 
+    isPhantom: function () {
+      return navigator.userAgent.toLowerCase().indexOf('phantom') !== -1;
+    },
+
     loadForm: function (name, action) {
       var $page = $('[data-role=page]');
       var $content = $page.find('[data-role=content]');

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -9,7 +9,57 @@ define(['BlinkForms'], function (Forms) {
       el.get('mode') === 'expanded';
   }
 
-  return {
+  var mod = {
+
+    loadForm: function (name, action) {
+      var $page = $('[data-role=page]');
+      var $content = $page.find('[data-role=content]');
+
+      $content.empty();
+      if (Forms.current) {
+        // Forms.current.close(); // breaks test/4
+        delete Forms.current;
+      }
+
+      return Forms.getDefinition(name, action)
+      .then(function (def) {
+        Forms.initialize(def, action);
+        form = Forms.current;
+
+        return new Promise(function (resolve) {
+          $(document).one('pageinit', function () {
+            resolve();
+          });
+
+          $content.append(form.$form);
+          $.mobile.page({}, $page);
+          $page.trigger('pagecreate');
+          $page.show();
+        });
+      });
+    },
+
+    defineFormLoadSuite: function (name, action) {
+      suite(name + ': ' + action, function () {
+        var $page = $('[data-role=page]');
+        var $content = $page.find('[data-role=content]');
+
+        test('BlinkForms global is an Object', function () {
+          assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
+        });
+
+        test('initialise with form.json', function () {
+          return mod.loadForm(name, action)
+          .then(function () {
+            var form = Forms.current;
+            assert.equal($.type(form), 'object');
+            assert.equal(form.get('name'), name);
+          });
+        });
+
+        mod.defineLabelTest();
+      });
+    },
 
     defineButtonTest: function () {
       test('jQM buttons displayed correctly', function () {
@@ -57,5 +107,7 @@ define(['BlinkForms'], function (Forms) {
     }
 
   };
+
+  return mod;
 
 });


### PR DESCRIPTION
- reduce at least 3 different ways we were loading form definitions down to 1 with assertions and 1 without
- updated tests 1-3, 5-24, 29-33
- all tests double-checked in Chrome and in PhantomJS
