### PR TITLE
FORMS-202 # form selectively removes elements when reusing inner form

### DIFF
--- a/docs/console-warnings.md
+++ b/docs/console-warnings.md
@@ -1,0 +1,28 @@
+# Console Warnings
+
+## Conditional Logic uses a hidden Element: <elementName>
+
+This warning means that in the forms builder you have defined an element in a subform as hidden, however the form that is displaying the subform has marked the field as 'H'.
+
+For example, say you have the following form, `Streets`
+
+    Field Name   | Field Type
+    -------------+-----------
+    Name         | TextElement
+    StreetType   | Select
+    Suburb       | Select
+
+
+And you have another form, `PostalRoute`, which uses `Streets` as a sub form:
+
+    Field Name   | Field Type
+    -------------+-----------
+    RouteName    | TextElement
+    PostPerson   | Select
+    StreetsField | Subform (Displays the `Streets` form, defined above)
+
+FormsBuilder gives you the ability to edit the `StreetsField` field in `PostalRoute` and modify the definition of the `Streets` form to remove fields when the `Streets` Form is displayed as a Subform of `PostalRoute` (the 'H' column). This removal only happens in the `PostalRoute` form and does not affect other forms that use `Streets`. If you mark a field as removed, then any conditional logic on the sub form that references this field will receive `undefined` as the value. This usually means that the form design and interactions of the conditional logic is over complicated and should be re-worked into something easier to work with and debug, so the console warning `Conditional Logic uses a hidden Element: <elementName>` is emitted.
+
+## Cordova Camera cannot be found
+
+This means that forms is unable to detect the Cordova Camera

--- a/forms/models/behaviour.js
+++ b/forms/models/behaviour.js
@@ -23,6 +23,10 @@ define(function (require) {
   var Behaviour;
 
   Expression.fn['formelement.value'] = function (name) {
+    var el = this.getElement(name);
+    if (!el) {
+      return undefined;
+    }
     return this.getElement(name).val();
   };
 

--- a/forms/models/behaviour.js
+++ b/forms/models/behaviour.js
@@ -25,6 +25,9 @@ define(function (require) {
   Expression.fn['formelement.value'] = function (name) {
     var el = this.getElement(name);
     if (!el) {
+      /* eslint-disable no-console */
+      console && console.warn('Conditional Logic uses a hidden Element: ' + name);
+      /* eslint-enable no-console */
       return undefined;
     }
     return this.getElement(name).val();

--- a/forms/models/behaviour.js
+++ b/forms/models/behaviour.js
@@ -30,7 +30,7 @@ define(function (require) {
       /* eslint-enable no-console */
       return undefined;
     }
-    return this.getElement(name).val();
+    return el.val();
   };
 
   Expression.fn.optionsbyxpath = function (xmlNodes) {

--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -73,10 +73,6 @@ define(function (require) {
         this.set('label', attrs.label);
       }
 
-      if (attrs.hide && parseInt(attrs.hide, 10)) {
-        this.set({hidden: true});
-      }
-
       // backward compatability.
       this.on('invalid change:value', this.updateErrors, this);
 

--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -39,7 +39,6 @@ define(function (require) {
       var page = attrs.page;
       var Forms = BMP.Forms;
       var section = $.trim(attrs.section || '');
-
       // migrate builder rowClass to class
       attrs.class = attrs.class || attrs.rowClass || '';
 
@@ -72,6 +71,10 @@ define(function (require) {
 
       if (attrs.label) {
         this.set('label', attrs.label);
+      }
+
+      if (attrs.hide && parseInt(attrs.hide, 10)) {
+        this.set({hidden: true});
       }
 
       // backward compatability.

--- a/forms/models/elements/subform.js
+++ b/forms/models/elements/subform.js
@@ -176,9 +176,9 @@ define(function (require) {
               // check the sub form field for any overridden properties.
               var overriddenOptions = fieldProperties[element.subForm || element.name];
 
-              // for now just apply the hidden override.
-              // TODO: implement the other subform overrides when their behavior has been defined.
-              element.hidden = overriddenOptions && parseInt(overriddenOptions.hide, 10) === 1;
+              if (overriddenOptions && parseInt(overriddenOptions.hide, 10) === 1) {
+                return memo;
+              }
 
               // let the element know who its parent is
               element.parentElement = self;

--- a/test/30_Subforms_inside_subforms/definitions.js
+++ b/test/30_Subforms_inside_subforms/definitions.js
@@ -1,110 +1,6 @@
 define(function () {
-  return [{
+    return [{
         "default": {
-            "uniqueNameId": "349lq",
-            "name": "filetest",
-            "formDescription": "",
-            "defaultCategory": "",
-            "maxStep": 6,
-            "labelPlacement": "auto",
-            "header": "",
-            "footer": "",
-            "_elements": [{
-                "default": {
-                    "name": "id",
-                    "type": "text",
-                    "page": 0
-                }
-            }, {
-                "default": {
-                    "name": "upload",
-                    "type": "file",
-                    "label": "Upload",
-                    "page": 0
-                }
-            }, {
-                "default": {
-                    "name": "text",
-                    "type": "text",
-                    "label": "Text",
-                    "page": 0
-                }
-            }],
-            "_checks": [],
-            "_actions": [],
-            "_behaviours": []
-        },
-        "list": {
-            "interaction": "FILETEST_LIST",
-            "displayName": "FILETEST LIST",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": null,
-            "action": "list",
-            "orderBy": null,
-            "showLink": {
-                "edit": "1",
-                "view": "1",
-                "delete": "1"
-            },
-            "dataStorageList": "temporary",
-            "downloadModeList": "partial",
-            "recordsToDisplay": "",
-            "_elements": ["upload", "text"]
-        },
-        "search": {
-            "interaction": "",
-            "displayName": null,
-            "defaultCategory": null,
-            "header": null,
-            "footer": null,
-            "hidden": null,
-            "action": "search"
-        },
-        "add": {
-            "interaction": "FILETEST_ADD",
-            "displayName": "FILETEST ADD",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": null,
-            "action": "add",
-            "_elements": ["upload", "text"]
-        },
-        "edit": {
-            "interaction": "FILETEST_EDIT",
-            "displayName": "FILETEST EDIT",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": "1",
-            "action": "edit",
-            "_elements": ["upload", "text"]
-        },
-        "view": {
-            "interaction": "FILETEST_VIEW",
-            "displayName": "FILETEST VIEW",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": "1",
-            "action": "view",
-            "_elements": ["upload", "text"]
-        },
-        "delete": {
-            "interaction": "FILETEST_DELETE",
-            "displayName": "FILETEST DELETE",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": "1",
-            "action": "delete",
-            "_elements": ["upload", "text"]
-        }
-    },
-    {
-      "default": {
             "uniqueNameId": "22uehx",
             "name": "firstLevel",
             "formDescription": "",
@@ -123,44 +19,76 @@ define(function () {
                 "default": {
                     "name": "first_level_req",
                     "type": "text",
-                    "label": "First Level Req",
+                    "label": "First & Level eq",
                     "labelPlacement": "default",
                     "labelStyle": "Plain",
                     "required": "1",
                     "maxWidthPrefix": "characters",
                     "page": 0
-                },
-                "list": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "add": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "edit": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "view": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "delete": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
                 }
             }, {
                 "default": {
-                    "name": "second_level_form",
+                    "name": "second_level_test",
                     "type": "subForm",
-                    "subForm": "second_level_form",
+                    "subForm": "second_level_field",
+                    "_elements": {
+                        "second|level|text": {
+                            "hide": "",
+                            "override": "",
+                            "type": "textbox",
+                            "id": "second_level_text"
+                        },
+                        "hidden|when|first": {
+                            "override": "",
+                            "type": "textbox",
+                            "id": "hidden_when_first",
+                            "hide": "1"
+                        },
+                        "hidden|when|text|is|a": {
+                            "hide": "",
+                            "override": "",
+                            "type": "textbox",
+                            "id": "hidden_when_text_is_a"
+                        },
+                        "third|level": {
+                            "hide": "",
+                            "override": "",
+                            "type": "sub_form",
+                            "id": "third_level"
+                        }
+                    },
+                    "plusButtonLabel": "Default plus button label",
+                    "minusButtonLabel": "Default minus button label",
+                    "labelPlacement": "default",
+                    "labelStyle": "Plain",
+                    "tooltip": "Default Tooltip",
+                    "rowClass": "default-class",
+                    "subformControlPos": "below",
+                    "subformPerms": "allow_add",
+                    "preload": "no",
                     "page": 0
+                },
+                "add": {
+                    "customise": "1",
+                    "plusButtonLabel": "Override_Plus",
+                    "minusButtonLabel": "Override_Minus",
+                    "labelPlacement": "above",
+                    "labelStyle": "Italic",
+                    "tooltip": "this is overridden tooltip text on add tab",
+                    "hint": "this is overridden hint text on add tab",
+                    "rowClass": "override",
+                    "rowStyle": "background-color:#0F0",
+                    "subformControlPos": "above"
+                },
+                "edit": {
+                    "minusButtonLabel": "Edit_Override minus",
+                    "labelPlacement": "left",
+                    "labelStyle": "Bold",
+                    "required": "1",
+                    "tooltip": "Edit override tooltip",
+                    "hint": "Edit override hinttext",
+                    "rowClass": "edit-override",
+                    "rowStyle": "background-color: #00f"
                 }
             }],
             "_checks": [],
@@ -184,10 +112,10 @@ define(function () {
             "dataStorageList": "temporary",
             "downloadModeList": "partial",
             "recordsToDisplay": "",
-            "_elements": ["first_level_req", "second_level_form"]
+            "_elements": ["first_level_req", "second_level_test"]
         },
         "search": {
-            "interaction": null,
+            "interaction": "",
             "displayName": null,
             "defaultCategory": null,
             "header": null,
@@ -203,7 +131,7 @@ define(function () {
             "footer": "",
             "hidden": null,
             "action": "add",
-            "_elements": ["first_level_req", "second_level_form"]
+            "_elements": ["first_level_req", "second_level_test"]
         },
         "edit": {
             "interaction": "FIRSTLEVEL_EDIT",
@@ -213,7 +141,7 @@ define(function () {
             "footer": "",
             "hidden": "1",
             "action": "edit",
-            "_elements": ["first_level_req", "second_level_form"]
+            "_elements": ["first_level_req", "second_level_test"]
         },
         "view": {
             "interaction": "FIRSTLEVEL_VIEW",
@@ -223,7 +151,7 @@ define(function () {
             "footer": "",
             "hidden": "1",
             "action": "view",
-            "_elements": ["first_level_req", "second_level_form"]
+            "_elements": ["first_level_req", "second_level_test"]
         },
         "delete": {
             "interaction": "FIRSTLEVEL_DELETE",
@@ -233,13 +161,12 @@ define(function () {
             "footer": "",
             "hidden": "1",
             "action": "delete",
-            "_elements": ["first_level_req", "second_level_form"]
+            "_elements": ["first_level_req", "second_level_test"]
         }
-    },
-    {
+    }, {
         "default": {
-            "uniqueNameId": "4aim",
-            "name": "outer_subform",
+            "uniqueNameId": "418tzdh0w6md",
+            "name": "second_level_field",
             "formDescription": "",
             "defaultCategory": "",
             "maxStep": 6,
@@ -254,98 +181,50 @@ define(function () {
                 }
             }, {
                 "default": {
-                    "name": "outer_name",
+                    "name": "second_level_text",
                     "type": "text",
-                    "label": "Outer Name",
+                    "label": "Second Level Text",
                     "labelPlacement": "default",
                     "labelStyle": "Plain",
                     "required": "1",
-                    "maxWidth": "2",
+                    "hint": "hidden when trigger_field contains b",
                     "maxWidthPrefix": "characters",
                     "page": 0
-                },
-                "list": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "add": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "edit": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "view": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "delete": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
                 }
             }, {
                 "default": {
-                    "name": "subform",
+                    "name": "hidden_when_first",
                     "type": "text",
-                    "label": "Subform",
+                    "label": "Hidden When First",
+                    "labelPlacement": "default",
+                    "labelStyle": "Plain",
+                    "hint": "hidden when trigger_field contains b",
+                    "maxWidthPrefix": "characters",
                     "page": 0
                 }
             }, {
                 "default": {
-                    "name": "file_test",
-                    "type": "subForm",
-                    "subForm": "filetest",
-                    "_elements": {
-                        "upload": {
-                            "hide": "",
-                            "override": "",
-                            "type": "file_upload",
-                            "id": "upload"
-                        },
-                        "text": {
-                            "hide": "",
-                            "override": "",
-                            "type": "textbox",
-                            "id": "text"
-                        }
-                    },
+                    "name": "hidden_when_text_is_a",
+                    "type": "text",
+                    "label": "Hidden When Text Is A",
                     "labelPlacement": "default",
                     "labelStyle": "Plain",
-                    "required": "1",
-                    "subformControlPos": "below",
-                    "maxSubforms": "10",
-                    "minSubforms": "2",
-                    "subformPerms": "allow_add",
-                    "preload": "no",
+                    "maxWidthPrefix": "characters",
                     "page": 0
-                },
-                "list": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain"
-                },
-                "add": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "subformControlPos": "below"
-                },
-                "edit": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "subformControlPos": "below"
-                },
-                "view": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain"
-                },
-                "delete": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain"
+                }
+            }, {
+                "default": {
+                    "name": "third_level",
+                    "type": "subForm",
+                    "subForm": "third_level_sub",
+                    "page": 0
+                }
+            }, {
+                "default": {
+                    "name": "trigger_field",
+                    "type": "text",
+                    "label": "Trigger Field",
+                    "page": 0
                 }
             }],
             "_checks": [],
@@ -353,8 +232,8 @@ define(function () {
             "_behaviours": []
         },
         "list": {
-            "interaction": "OUTER_SUBFORM_LIST",
-            "displayName": "OUTER_SUBFORM LIST",
+            "interaction": "",
+            "displayName": "",
             "defaultCategory": "",
             "header": "",
             "footer": "",
@@ -369,176 +248,7 @@ define(function () {
             "dataStorageList": "temporary",
             "downloadModeList": "partial",
             "recordsToDisplay": "",
-            "_elements": ["outer_name", "subform", "file_test"]
-        },
-        "search": {
-            "interaction": null,
-            "displayName": null,
-            "defaultCategory": null,
-            "header": null,
-            "footer": null,
-            "hidden": null,
-            "action": "search"
-        },
-        "add": {
-            "interaction": "OUTER_SUBFORM_ADD",
-            "displayName": "OUTER_SUBFORM ADD",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": null,
-            "action": "add",
-            "_elements": ["outer_name", "subform", "file_test"]
-        },
-        "edit": {
-            "interaction": "OUTER_SUBFORM_EDIT",
-            "displayName": "OUTER_SUBFORM EDIT",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": "1",
-            "action": "edit",
-            "_elements": ["outer_name", "subform", "file_test"]
-        },
-        "view": {
-            "interaction": "OUTER_SUBFORM_VIEW",
-            "displayName": "OUTER_SUBFORM VIEW",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": "1",
-            "action": "view",
-            "_elements": ["outer_name", "subform", "file_test"]
-        },
-        "delete": {
-            "interaction": "OUTER_SUBFORM_DELETE",
-            "displayName": "OUTER_SUBFORM DELETE",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": "1",
-            "action": "delete",
-            "_elements": ["outer_name", "subform", "file_test"]
-        }
-    },
-    {
-        "default": {
-            "uniqueNameId": "dm7b6vyym",
-            "name": "second_level_form",
-            "formDescription": "",
-            "defaultCategory": "",
-            "maxStep": 4,
-            "labelPlacement": null,
-            "header": null,
-            "footer": null,
-            "_elements": [{
-                "default": {
-                    "name": "id",
-                    "type": "text",
-                    "page": 0
-                }
-            }, {
-                "default": {
-                    "name": "second_required",
-                    "type": "text",
-                    "label": "Second Required",
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "required": "1",
-                    "maxWidthPrefix": "characters",
-                    "page": 0
-                },
-                "list": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "add": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "edit": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "view": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "delete": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                }
-            }, {
-                "default": {
-                    "name": "third_level_form",
-                    "type": "subForm",
-                    "subForm": "third_level_form",
-                    "page": 0
-                }
-            }, {
-                "default": {
-                    "name": "hidden_field1",
-                    "type": "text",
-                    "label": "Hidden with underscore",
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "required": "1",
-                    "maxWidthPrefix": "characters",
-                    "page": 0,
-                    "hide": "1"
-                }
-            }, {
-                "default": {
-                    "name": "hiddenfield2",
-                    "type": "text",
-                    "label": "Hidden without underscore",
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "required": "1",
-                    "maxWidthPrefix": "characters",
-                    "page": 0,
-                    "hide": "1"
-                }
-            }, {
-                "default": {
-                    "name": "hiddenfield3",
-                    "type": "text",
-                    "label": "Hide is 0, should be shown",
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "required": "1",
-                    "maxWidthPrefix": "characters",
-                    "page": 0,
-                    "hide": "0"
-                }
-            }],
-            "_checks": [],
-            "_actions": [],
-            "_behaviours": []
-        },
-        "list": {
-            "interaction": "",
-            "displayName": "",
-            "defaultCategory": "",
-            "header": null,
-            "footer": null,
-            "hidden": null,
-            "action": "list",
-            "orderBy": null,
-            "showLink": {
-                "edit": 1,
-                "view": 1,
-                "delete": 1
-            },
-            "dataStorageList": null,
-            "downloadModeList": null,
-            "recordsToDisplay": null,
-            "_elements": ["second_required", "third_level_form"]
+            "_elements": ["second_level_text", "hidden_when_first", "hidden_when_text_is_a"]
         },
         "search": {
             "interaction": null,
@@ -553,262 +263,46 @@ define(function () {
             "interaction": "",
             "displayName": "",
             "defaultCategory": "",
-            "header": null,
-            "footer": null,
+            "header": "",
+            "footer": "",
             "hidden": null,
             "action": "add",
-            "_elements": ["second_required", "third_level_form", "hidden_field1", "hiddenfield2", "hiddenfield3"]
+            "_elements": ["second_level_text", "hidden_when_first", "hidden_when_text_is_a", "third_level", "trigger_field"]
         },
         "edit": {
             "interaction": "",
             "displayName": "",
             "defaultCategory": "",
-            "header": null,
-            "footer": null,
+            "header": "",
+            "footer": "",
             "hidden": "1",
             "action": "edit",
-            "_elements": ["second_required", "third_level_form", "hidden_field1", "hiddenfield2", "hiddenfield3"]
+            "_elements": ["second_level_text", "hidden_when_first", "hidden_when_text_is_a", "third_level", "trigger_field"]
         },
         "view": {
             "interaction": "",
             "displayName": "",
             "defaultCategory": "",
-            "header": null,
-            "footer": null,
+            "header": "",
+            "footer": "",
             "hidden": "1",
             "action": "view",
-            "_elements": ["second_required", "third_level_form"]
+            "_elements": ["second_level_text", "hidden_when_first", "hidden_when_text_is_a", "third_level", "trigger_field"]
         },
         "delete": {
             "interaction": "",
             "displayName": "",
             "defaultCategory": "",
-            "header": null,
-            "footer": null,
-            "hidden": "1",
-            "action": "delete",
-            "_elements": ["second_required", "third_level_form"]
-        }
-    },
-    {
-        "default": {
-            "uniqueNameId": "3gep",
-            "name": "subform1",
-            "formDescription": "",
-            "defaultCategory": "",
-            "maxStep": 6,
-            "labelPlacement": "auto",
-            "header": "",
-            "footer": "",
-            "_elements": [{
-                "default": {
-                    "name": "id",
-                    "type": "text",
-                    "page": 0
-                }
-            }, {
-                "default": {
-                    "name": "name",
-                    "type": "text",
-                    "label": "Name",
-                    "page": 0
-                }
-            }],
-            "_checks": [],
-            "_actions": [],
-            "_behaviours": []
-        },
-        "list": {
-            "interaction": "SUBFORM1_LIST",
-            "displayName": "SUBFORM1 LIST",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": null,
-            "action": "list",
-            "orderBy": null,
-            "showLink": {
-                "edit": "1",
-                "view": "1",
-                "delete": "1"
-            },
-            "dataStorageList": "temporary",
-            "downloadModeList": "partial",
-            "recordsToDisplay": "",
-            "_elements": ["name"]
-        },
-        "search": {
-            "interaction": null,
-            "displayName": null,
-            "defaultCategory": null,
-            "header": null,
-            "footer": null,
-            "hidden": null,
-            "action": "search"
-        },
-        "add": {
-            "interaction": "SUBFORM1_ADD",
-            "displayName": "SUBFORM1 ADD",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": null,
-            "action": "add",
-            "_elements": ["name"]
-        },
-        "edit": {
-            "interaction": "SUBFORM1_EDIT",
-            "displayName": "SUBFORM1 EDIT",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": "1",
-            "action": "edit",
-            "_elements": ["name"]
-        },
-        "view": {
-            "interaction": "SUBFORM1_VIEW",
-            "displayName": "SUBFORM1 VIEW",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": "1",
-            "action": "view",
-            "_elements": ["name"]
-        },
-        "delete": {
-            "interaction": "SUBFORM1_DELETE",
-            "displayName": "SUBFORM1 DELETE",
-            "defaultCategory": "",
             "header": "",
             "footer": "",
             "hidden": "1",
             "action": "delete",
-            "_elements": ["name"]
+            "_elements": ["second_level_text", "hidden_when_first", "hidden_when_text_is_a", "third_level", "trigger_field"]
         }
-    },
-    {
-        "default": {
-            "uniqueNameId": "10v5qx2",
-            "name": "sub_form_holder",
-            "formDescription": "",
-            "defaultCategory": "",
-            "maxStep": 6,
-            "labelPlacement": "auto",
-            "header": "",
-            "footer": "",
-            "_elements": [{
-                "default": {
-                    "name": "id",
-                    "type": "text",
-                    "page": 0
-                }
-            }, {
-                "default": {
-                    "name": "name",
-                    "type": "text",
-                    "label": "Name",
-                    "page": 0
-                }
-            }, {
-                "default": {
-                    "name": "required",
-                    "type": "text",
-                    "label": "Required",
-                    "page": 0
-                }
-            }, {
-                "default": {
-                    "name": "not_required",
-                    "type": "text",
-                    "label": "Not Required",
-                    "page": 0
-                }
-            }, {
-                "default": {
-                    "name": "inception_form",
-                    "type": "subForm",
-                    "subForm": "outer_subform",
-                    "page": 0
-                }
-            }],
-            "_checks": [],
-            "_actions": [],
-            "_behaviours": []
-        },
-        "list": {
-            "interaction": "SUB_FORM_HOLDER_LIST",
-            "displayName": "SUB_FORM_HOLDER LIST",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": null,
-            "action": "list",
-            "orderBy": null,
-            "showLink": {
-                "edit": "1",
-                "view": "1",
-                "delete": "1"
-            },
-            "dataStorageList": "temporary",
-            "downloadModeList": "partial",
-            "recordsToDisplay": "",
-            "_elements": ["name", "required", "not_required"]
-        },
-        "search": {
-            "interaction": null,
-            "displayName": null,
-            "defaultCategory": null,
-            "header": null,
-            "footer": null,
-            "hidden": null,
-            "action": "search"
-        },
-        "add": {
-            "interaction": "SUB_FORM_HOLDER_ADD",
-            "displayName": "SUB_FORM_HOLDER ADD",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": null,
-            "action": "add",
-            "_elements": ["name", "required", "not_required", "inception_form"]
-        },
-        "edit": {
-            "interaction": "SUB_FORM_HOLDER_EDIT",
-            "displayName": "SUB_FORM_HOLDER EDIT",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": "1",
-            "action": "edit",
-            "_elements": ["name", "required", "not_required", "inception_form"]
-        },
-        "view": {
-            "interaction": "SUB_FORM_HOLDER_VIEW",
-            "displayName": "SUB_FORM_HOLDER VIEW",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": "1",
-            "action": "view",
-            "_elements": ["name", "required", "not_required", "inception_form"]
-        },
-        "delete": {
-            "interaction": "SUB_FORM_HOLDER_DELETE",
-            "displayName": "SUB_FORM_HOLDER DELETE",
-            "defaultCategory": "",
-            "header": "",
-            "footer": "",
-            "hidden": "1",
-            "action": "delete",
-            "_elements": ["name", "required", "not_required", "inception_form"]
-        }
-    },
-    {
+    }, {
         "default": {
             "uniqueNameId": "11g78byb",
-            "name": "third_level_form",
+            "name": "third_level_sub",
             "formDescription": "",
             "defaultCategory": "",
             "maxStep": 4,
@@ -831,31 +325,6 @@ define(function () {
                     "required": "1",
                     "maxWidthPrefix": "characters",
                     "page": 0
-                },
-                "list": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "add": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "edit": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "view": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
-                },
-                "delete": {
-                    "labelPlacement": "default",
-                    "labelStyle": "Plain",
-                    "maxWidthPrefix": "characters"
                 }
             }],
             "_checks": [],
@@ -930,6 +399,5 @@ define(function () {
             "action": "delete",
             "_elements": ["third_level_req"]
         }
-    }
-];
+    }];
 });

--- a/test/30_Subforms_inside_subforms/definitions.js
+++ b/test/30_Subforms_inside_subforms/definitions.js
@@ -480,6 +480,42 @@ define(function () {
                     "subForm": "third_level_form",
                     "page": 0
                 }
+            }, {
+                "default": {
+                    "name": "hidden_field1",
+                    "type": "text",
+                    "label": "Hidden with underscore",
+                    "labelPlacement": "default",
+                    "labelStyle": "Plain",
+                    "required": "1",
+                    "maxWidthPrefix": "characters",
+                    "page": 0,
+                    "hide": "1"
+                }
+            }, {
+                "default": {
+                    "name": "hiddenfield2",
+                    "type": "text",
+                    "label": "Hidden without underscore",
+                    "labelPlacement": "default",
+                    "labelStyle": "Plain",
+                    "required": "1",
+                    "maxWidthPrefix": "characters",
+                    "page": 0,
+                    "hide": "1"
+                }
+            }, {
+                "default": {
+                    "name": "hiddenfield3",
+                    "type": "text",
+                    "label": "Hide is 0, should be shown",
+                    "labelPlacement": "default",
+                    "labelStyle": "Plain",
+                    "required": "1",
+                    "maxWidthPrefix": "characters",
+                    "page": 0,
+                    "hide": "0"
+                }
             }],
             "_checks": [],
             "_actions": [],
@@ -521,7 +557,7 @@ define(function () {
             "footer": null,
             "hidden": null,
             "action": "add",
-            "_elements": ["second_required", "third_level_form"]
+            "_elements": ["second_required", "third_level_form", "hidden_field1", "hiddenfield2", "hiddenfield3"]
         },
         "edit": {
             "interaction": "",
@@ -531,7 +567,7 @@ define(function () {
             "footer": null,
             "hidden": "1",
             "action": "edit",
-            "_elements": ["second_required", "third_level_form"]
+            "_elements": ["second_required", "third_level_form", "hidden_field1", "hiddenfield2", "hiddenfield3"]
         },
         "view": {
             "interaction": "",

--- a/test/30_Subforms_inside_subforms/test.js
+++ b/test/30_Subforms_inside_subforms/test.js
@@ -174,5 +174,38 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
                     thirdLevelRequiredField.val('hello');
                   });
     });
+
+    suite('hidden subform fields', function () {
+      setup(function () {
+        return Forms.current.getElement('second_level_form').add();
+      });
+
+      test('hidden fields in the name are not shown', function () {
+        var hiddenField = Forms.current.getElement('hidden_field1'),
+            hiddenFieldView = hiddenField.get('_view');
+
+        assert.isTrue(hiddenField.get('hidden'));
+        assert.isFalse(hiddenFieldView.$el.is(':visible'));
+
+      });
+
+      test('hidden fields with underscore in the name are not shown', function () {
+        var hiddenFieldWithUnderscore = Forms.current.getElement('hiddenfield2'),
+            hiddenFieldWithUnderscoreView = hiddenFieldWithUnderscore.get('_view');
+
+        assert.isTrue(hiddenFieldWithUnderscore.get('hidden'));
+        assert.isFalse(hiddenFieldWithUnderscoreView.$el.is(':visible'));
+
+      });
+
+      test('fields with a hide attribute that is falsy are shown', function () {
+        var model = Forms.current.getElement('hiddenfield3'),
+            view = model.get('_view');
+
+        assert.isFalse(model.get('hidden'));
+        assert.isTrue(view.$el.is(':visible'));
+
+      });
+    });
   });
 });

--- a/test/30_Subforms_inside_subforms/test.js
+++ b/test/30_Subforms_inside_subforms/test.js
@@ -13,7 +13,7 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
       var subForms = Forms.current.getSubforms();
       var p, counter = 0;
       assert.isObject(subForms);
-      assert.isDefined(subForms.second_level_form);
+      assert.isDefined(subForms.second_level_test);
       for (p in subForms) {
         if (subForms.hasOwnProperty(p)) {
           counter++;
@@ -24,49 +24,49 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
     });
 
     test('2nd level form returns 1 subform', function () {
-      return Forms.current.getElement('second_level_form').get('_view').onAddClick().then(function () {
+      return Forms.current.getElement('second_level_test').add().then(function () {
         var subForms;
         var subSubForms;
         subForms = Forms.current.getSubforms();
-        assert.equal(subForms.second_level_form.length, 1);
+        assert.equal(subForms.second_level_test.length, 1);
 
-        subSubForms = subForms.second_level_form.invoke('getSubforms')[0];
-        assert.isDefined(subSubForms.third_level_form);
+        subSubForms = subForms.second_level_test.invoke('getSubforms')[0];
+        assert.isDefined(subSubForms.third_level);
       });
     });
 
     test('2nd level form returns 2 subforms', function () {
-      var view = Forms.current.getElement('second_level_form').get('_view');
-      return view.onAddClick()
-                  .then(view.onAddClick.bind(view))
+      var subform = Forms.current.getElement('second_level_test');
+      return subform.add()
+                  .then(subform.add.bind(subform))
                   .then(function () {
                     var subForms;
                     var subSubForms;
                     subForms = Forms.current.getSubforms();
-                    assert.equal(subForms.second_level_form.length, 2);
-                    subSubForms = subForms.second_level_form.models[0].getSubforms();
-                    assert.isDefined(subSubForms.third_level_form);
+                    assert.equal(subForms.second_level_test.length, 2);
+                    subSubForms = subForms.second_level_test.models[0].getSubforms();
+                    assert.isDefined(subSubForms.third_level);
                   });
     });
 
     test('2nd level form returns 2 subforms', function () {
-      var view = Forms.current.getElement('second_level_form').get('_view');
-      return view.onAddClick()
-                  .then(view.onAddClick.bind(view))
+      var subform = Forms.current.getElement('second_level_test');
+      return subform.add()
+                  .then(subform.add.bind(subform))
                   .then(function () {
                     var subForms;
                     var subSubForms;
                     subForms = Forms.current.getSubforms();
-                    assert.equal(subForms.second_level_form.length, 2);
-                    subSubForms = subForms.second_level_form.models[0].getSubforms();
-                    assert.isDefined(subSubForms.third_level_form);
+                    assert.equal(subForms.second_level_test.length, 2);
+                    subSubForms = subForms.second_level_test.models[0].getSubforms();
+                    assert.isDefined(subSubForms.third_level);
                   });
     });
 
     test('2nd level form errors are scrolled to', function () {
       var origScrollTop = $(window).scrollTop();
-      var view = Forms.current.getElement('second_level_form').get('_view');
-      return view.onAddClick()
+      var subform = Forms.current.getElement('second_level_test');
+      return subform.add()
                  .then(function () {
                   var invalid = Forms.current.getInvalidElements();
                   // make sure we have an error
@@ -81,22 +81,21 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
     test('3rd level form errors are scrolled to correctly', function () {
       var origScrollTop = $(window).scrollTop();
-      var view = Forms.current.getElement('second_level_form').get('_view');
+      var subform = Forms.current.getElement('second_level_test');
 
-      return view.onAddClick() // add second level
+      return subform.add() // add second level
                   .then(function () {
-                    var t = Forms.current.getElement('third_level_form').get('_view');
-                    return t.onAddClick(); // add third level
+                    return Forms.current.getElement('third_level').add(); // add third level
                   })
                   .then(function () {
                     var subForms = Forms.current.getSubforms();
-                    var moreSubforms = subForms.second_level_form.getSubforms();
+                    var moreSubforms = subForms.second_level_test.getSubforms();
                     var invalidThirdLevel;
                     // make sure we have an error
                     assert.isAbove(moreSubforms.length, 0);
-                    assert.isTrue(moreSubforms[0].hasOwnProperty('third_level_form'));
+                    assert.isTrue(moreSubforms[0].hasOwnProperty('third_level'));
                     // get the first invalid element and scroll
-                    invalidThirdLevel = moreSubforms[0].third_level_form.models[0].getInvalidElements();
+                    invalidThirdLevel = moreSubforms[0].third_level.models[0].getInvalidElements();
                     assert.isAbove(invalidThirdLevel.errors.length, 0);
 
                     return invalidThirdLevel.errors[0].get('_view').scrollTo().then(function () {
@@ -106,40 +105,39 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
     });
 
     test('subform invalid events bubble up to Forms.current', function (done) {
-      var view = Forms.current.getElement('second_level_form').get('_view');
+      var subform = Forms.current.getElement('second_level_test');
 
-      view.onAddClick()
-          .then(function () {
-            Forms.current.on('invalid', function (model, error) {
-              assert.equal(model.id, 'second_required');
-              assert.equal(error.value[0].code, 'REQUIRED');
-              done();
-            });
-            Forms.current.getElement('second_required').val('');
-          });
+      subform.add()
+              .then(function () {
+                Forms.current.on('invalid', function (model, error) {
+                  assert.equal(model.id, 'second_level_text');
+                  assert.equal(error.value[0].code, 'REQUIRED');
+                  done();
+                });
+                Forms.current.getElement('second_level_text').val('');
+              });
     });
 
     test('subform change:value events bubble up to Forms.current', function (done) {
-      var view = Forms.current.getElement('second_level_form').get('_view');
+      var subform = Forms.current.getElement('second_level_test');
 
-      view.onAddClick()
-          .then(function () {
-            Forms.current.on('change:value', function (model, val) {
-              assert.equal(model.id, 'second_required');
-              assert.equal(val, 123);
-              done();
-            });
-            Forms.current.getElement('second_required').val(123);
-          });
+      subform.add()
+              .then(function () {
+                Forms.current.on('change:value', function (model, val) {
+                  assert.equal(model.id, 'second_level_text');
+                  assert.equal(val, 123);
+                  done();
+                });
+                Forms.current.getElement('second_level_text').val(123);
+              });
     });
 
     test('3rd level subform invalid events bubble up to Forms.current', function (done) {
-      var view = Forms.current.getElement('second_level_form').get('_view');
+      var subform = Forms.current.getElement('second_level_test');
 
-      return view.onAddClick() // add second level
+      return subform.add() // add second level
                   .then(function () {
-                    var t = Forms.current.getElement('third_level_form').get('_view');
-                    return t.onAddClick(); // add third level
+                    return Forms.current.getElement('third_level').add(); // add third level
                   })
                   .then(function () {
                     var thirdLevelRequiredField = Forms.current.getElement('third_level_req');
@@ -155,12 +153,11 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
     });
 
     test('3rd level subform invalid events bubble up to Forms.current', function (done) {
-      var view = Forms.current.getElement('second_level_form').get('_view');
+      var subform = Forms.current.getElement('second_level_test');
 
-      return view.onAddClick() // add second level
+      return subform.add() // add second level
                   .then(function () {
-                    var t = Forms.current.getElement('third_level_form').get('_view');
-                    return t.onAddClick(); // add third level
+                    return Forms.current.getElement('third_level').add(); // add third level
                   })
                   .then(function () {
                     var thirdLevelRequiredField = Forms.current.getElement('third_level_req');
@@ -177,29 +174,16 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
 
     suite('hidden subform fields', function () {
       setup(function () {
-        return Forms.current.getElement('second_level_form').add();
-      });
-
-      test('hidden fields in the name are not shown', function () {
-        var hiddenField = Forms.current.getElement('hidden_field1'),
-            hiddenFieldView = hiddenField.get('_view');
-
-        assert.isTrue(hiddenField.get('hidden'));
-        assert.isFalse(hiddenFieldView.$el.is(':visible'));
-
+        return Forms.current.getElement('second_level_test').add();
       });
 
       test('hidden fields with underscore in the name are not shown', function () {
-        var hiddenFieldWithUnderscore = Forms.current.getElement('hiddenfield2'),
-            hiddenFieldWithUnderscoreView = hiddenFieldWithUnderscore.get('_view');
-
-        assert.isTrue(hiddenFieldWithUnderscore.get('hidden'));
-        assert.isFalse(hiddenFieldWithUnderscoreView.$el.is(':visible'));
+        assert.isUndefined(Forms.current.getElement('hidden_when_first'));
 
       });
 
       test('fields with a hide attribute that is falsy are shown', function () {
-        var model = Forms.current.getElement('hiddenfield3'),
+        var model = Forms.current.getElement('hidden_when_text_is_a'),
             view = model.get('_view');
 
         assert.isFalse(model.get('hidden'));

--- a/test/31_3_condition_logic_and_hidden_fields/definitions.js
+++ b/test/31_3_condition_logic_and_hidden_fields/definitions.js
@@ -1,0 +1,489 @@
+define(function(require) {
+    'use strict';
+
+    return [{
+        "default": {
+            "uniqueNameId": "22uehx",
+            "name": "firstLevel",
+            "formDescription": "",
+            "defaultCategory": "",
+            "maxStep": 6,
+            "labelPlacement": "auto",
+            "header": "",
+            "footer": "",
+            "_elements": [{
+                "default": {
+                    "name": "id",
+                    "type": "text",
+                    "page": 0
+                }
+            }, {
+                "default": {
+                    "name": "first_level_req",
+                    "type": "text",
+                    "label": "First & Level eq",
+                    "labelPlacement": "default",
+                    "labelStyle": "Plain",
+                    "required": "1",
+                    "maxWidthPrefix": "characters",
+                    "page": 0
+                }
+            }, {
+                "default": {
+                    "name": "second_level_test",
+                    "type": "subForm",
+                    "subForm": "second_level_field",
+                    "_elements": {
+                        "second|level|text": {
+                            "hide": "",
+                            "override": "",
+                            "type": "textbox",
+                            "id": "second_level_text"
+                        },
+                        "hidden|when|first": {
+                            "override": "",
+                            "type": "textbox",
+                            "id": "hidden_when_first",
+                            "hide": "1"
+                        },
+                        "hidden|when|text|is|a": {
+                            "hide": "",
+                            "override": "",
+                            "type": "textbox",
+                            "id": "hidden_when_text_is_a"
+                        },
+                        "third|level": {
+                            "hide": "",
+                            "override": "",
+                            "type": "sub_form",
+                            "id": "third_level"
+                        }
+                    },
+                    "plusButtonLabel": "Default plus button label",
+                    "minusButtonLabel": "Default minus button label",
+                    "labelPlacement": "default",
+                    "labelStyle": "Plain",
+                    "tooltip": "Default Tooltip",
+                    "rowClass": "default-class",
+                    "subformControlPos": "below",
+                    "subformPerms": "allow_add",
+                    "preload": "no",
+                    "page": 0
+                },
+                "add": {
+                    "customise": "1",
+                    "plusButtonLabel": "Override_Plus",
+                    "minusButtonLabel": "Override_Minus",
+                    "labelPlacement": "above",
+                    "labelStyle": "Italic",
+                    "tooltip": "this is overridden tooltip text on add tab",
+                    "hint": "this is overridden hint text on add tab",
+                    "rowClass": "override",
+                    "rowStyle": "background-color:#0F0",
+                    "subformControlPos": "above"
+                },
+                "edit": {
+                    "minusButtonLabel": "Edit_Override minus",
+                    "labelPlacement": "left",
+                    "labelStyle": "Bold",
+                    "required": "1",
+                    "tooltip": "Edit override tooltip",
+                    "hint": "Edit override hinttext",
+                    "rowClass": "edit-override",
+                    "rowStyle": "background-color: #00f"
+                }
+            }],
+            "_checks": [],
+            "_actions": [],
+            "_behaviours": []
+        },
+        "list": {
+            "interaction": "FIRSTLEVEL_LIST",
+            "displayName": "FIRSTLEVEL LIST",
+            "defaultCategory": "",
+            "header": "",
+            "footer": "",
+            "hidden": null,
+            "action": "list",
+            "orderBy": null,
+            "showLink": {
+                "edit": "1",
+                "view": "1",
+                "delete": "1"
+            },
+            "dataStorageList": "temporary",
+            "downloadModeList": "partial",
+            "recordsToDisplay": "",
+            "_elements": ["first_level_req", "second_level_test"]
+        },
+        "search": {
+            "interaction": "",
+            "displayName": null,
+            "defaultCategory": null,
+            "header": null,
+            "footer": null,
+            "hidden": null,
+            "action": "search"
+        },
+        "add": {
+            "interaction": "FIRSTLEVEL_ADD",
+            "displayName": "FIRSTLEVEL ADD",
+            "defaultCategory": "",
+            "header": "",
+            "footer": "",
+            "hidden": null,
+            "action": "add",
+            "_elements": ["first_level_req", "second_level_test"]
+        },
+        "edit": {
+            "interaction": "FIRSTLEVEL_EDIT",
+            "displayName": "FIRSTLEVEL EDIT",
+            "defaultCategory": "",
+            "header": "",
+            "footer": "",
+            "hidden": "1",
+            "action": "edit",
+            "_elements": ["first_level_req", "second_level_test"]
+        },
+        "view": {
+            "interaction": "FIRSTLEVEL_VIEW",
+            "displayName": "FIRSTLEVEL VIEW",
+            "defaultCategory": "",
+            "header": "",
+            "footer": "",
+            "hidden": "1",
+            "action": "view",
+            "_elements": ["first_level_req", "second_level_test"]
+        },
+        "delete": {
+            "interaction": "FIRSTLEVEL_DELETE",
+            "displayName": "FIRSTLEVEL DELETE",
+            "defaultCategory": "",
+            "header": "",
+            "footer": "",
+            "hidden": "1",
+            "action": "delete",
+            "_elements": ["first_level_req", "second_level_test"]
+        }
+    }, {
+        "default": {
+            "uniqueNameId": "418tzdh0w6md",
+            "name": "second_level_field",
+            "formDescription": "",
+            "defaultCategory": "",
+            "maxStep": 6,
+            "labelPlacement": "auto",
+            "header": "",
+            "footer": "",
+            "_elements": [{
+                "default": {
+                    "name": "id",
+                    "type": "text",
+                    "page": 0
+                }
+            }, {
+                "default": {
+                    "name": "second_level_text",
+                    "type": "text",
+                    "label": "Second Level Text",
+                    "labelPlacement": "default",
+                    "labelStyle": "Plain",
+                    "required": "1",
+                    "hint": "hidden when trigger_field contains b",
+                    "maxWidthPrefix": "characters",
+                    "page": 0
+                }
+            }, {
+                "default": {
+                    "name": "hidden_when_first",
+                    "type": "text",
+                    "label": "Hidden When First",
+                    "labelPlacement": "default",
+                    "labelStyle": "Plain",
+                    "hint": "hidden when trigger_field contains b",
+                    "maxWidthPrefix": "characters",
+                    "page": 0
+                }
+            }, {
+                "default": {
+                    "name": "hidden_when_text_is_a",
+                    "type": "text",
+                    "label": "Hidden When Text Is A",
+                    "labelPlacement": "default",
+                    "labelStyle": "Plain",
+                    "maxWidthPrefix": "characters",
+                    "page": 0
+                }
+            }, {
+                "default": {
+                    "name": "third_level",
+                    "type": "subForm",
+                    "subForm": "third_level_sub",
+                    "page": 0
+                }
+            }, {
+                "default": {
+                    "name": "trigger_field",
+                    "type": "text",
+                    "label": "Trigger Field",
+                    "page": 0
+                }
+            }],
+            "_checks": [{
+                "default": {
+                    "name": "triggerFieldContainsB",
+                    "exp": {
+                        "operator": "contains",
+                        "operands": [{
+                            "operator": "formElement.value",
+                            "operands": ["trigger_field"]
+                        }, "b"]
+                    }
+                }
+            }, {
+                "default": {
+                    "name": "hiddenWhenFirstIsA",
+                    "exp": {
+                        "operator": "==",
+                        "operands": [{
+                            "operator": "formElement.value",
+                            "operands": ["hidden_when_first"]
+                        }, "a"]
+                    }
+                }
+            }],
+            "_actions": [{
+                "default": {
+                    "name": "hideSecondLevelText",
+                    "manipulations": [{
+                        "target": "second_level_text",
+                        "properties": {
+                            "hidden": true,
+                            "persist": false
+                        }
+                    }]
+                }
+            }, {
+                "default": {
+                    "name": "hideHiddenWhenFirst",
+                    "manipulations": [{
+                        "target": "hidden_when_first",
+                        "properties": {
+                            "hidden": true,
+                            "persist": false
+                        }
+                    }]
+                }
+            }, {
+                "default": {
+                    "name": "hideHiddenWhenTextIsA",
+                    "manipulations": [{
+                        "target": "hidden_when_text_is_a",
+                        "properties": {
+                            "hidden": true,
+                            "persist": false
+                        }
+                    }]
+                }
+            }],
+            "_behaviours": [{
+                "default": {
+                    "name": "hideSecondLevelText_triggerFieldContainsB_hideHiddenWhenFirst_triggerFieldContainsB",
+                    "trigger": {
+                        "formElements": ["trigger_field"],
+                        "formEvents": ["load"]
+                    },
+                    "check": "triggerFieldContainsB",
+                    "actions": [{
+                        "action": "hideSecondLevelText",
+                        "autoReverse": true
+                    }, {
+                        "action": "hideHiddenWhenFirst",
+                        "autoReverse": true
+                    }]
+                }
+            }, {
+                "default": {
+                    "name": "hideHiddenWhenTextIsA_hiddenWhenFirstIsA",
+                    "trigger": {
+                        "formElements": ["hidden_when_first"],
+                        "formEvents": ["load"]
+                    },
+                    "check": "hiddenWhenFirstIsA",
+                    "actions": [{
+                        "action": "hideHiddenWhenTextIsA",
+                        "autoReverse": true
+                    }]
+                }
+            }]
+        },
+        "list": {
+            "interaction": "",
+            "displayName": "",
+            "defaultCategory": "",
+            "header": "",
+            "footer": "",
+            "hidden": null,
+            "action": "list",
+            "orderBy": null,
+            "showLink": {
+                "edit": "1",
+                "view": "1",
+                "delete": "1"
+            },
+            "dataStorageList": "temporary",
+            "downloadModeList": "partial",
+            "recordsToDisplay": "",
+            "_elements": ["second_level_text", "hidden_when_first", "hidden_when_text_is_a"]
+        },
+        "search": {
+            "interaction": null,
+            "displayName": null,
+            "defaultCategory": null,
+            "header": null,
+            "footer": null,
+            "hidden": null,
+            "action": "search"
+        },
+        "add": {
+            "interaction": "",
+            "displayName": "",
+            "defaultCategory": "",
+            "header": "",
+            "footer": "",
+            "hidden": null,
+            "action": "add",
+            "_elements": ["second_level_text", "hidden_when_first", "hidden_when_text_is_a", "third_level", "trigger_field"]
+        },
+        "edit": {
+            "interaction": "",
+            "displayName": "",
+            "defaultCategory": "",
+            "header": "",
+            "footer": "",
+            "hidden": "1",
+            "action": "edit",
+            "_elements": ["second_level_text", "hidden_when_first", "hidden_when_text_is_a", "third_level", "trigger_field"]
+        },
+        "view": {
+            "interaction": "",
+            "displayName": "",
+            "defaultCategory": "",
+            "header": "",
+            "footer": "",
+            "hidden": "1",
+            "action": "view",
+            "_elements": ["second_level_text", "hidden_when_first", "hidden_when_text_is_a", "third_level", "trigger_field"]
+        },
+        "delete": {
+            "interaction": "",
+            "displayName": "",
+            "defaultCategory": "",
+            "header": "",
+            "footer": "",
+            "hidden": "1",
+            "action": "delete",
+            "_elements": ["second_level_text", "hidden_when_first", "hidden_when_text_is_a", "third_level", "trigger_field"]
+        }
+    }, {
+        "default": {
+            "uniqueNameId": "11g78byb",
+            "name": "third_level_sub",
+            "formDescription": "",
+            "defaultCategory": "",
+            "maxStep": 4,
+            "labelPlacement": null,
+            "header": null,
+            "footer": null,
+            "_elements": [{
+                "default": {
+                    "name": "id",
+                    "type": "text",
+                    "page": 0
+                }
+            }, {
+                "default": {
+                    "name": "third_level_req",
+                    "type": "text",
+                    "label": "Third Level Req",
+                    "labelPlacement": "default",
+                    "labelStyle": "Plain",
+                    "required": "1",
+                    "maxWidthPrefix": "characters",
+                    "page": 0
+                }
+            }],
+            "_checks": [],
+            "_actions": [],
+            "_behaviours": []
+        },
+        "list": {
+            "interaction": "",
+            "displayName": "",
+            "defaultCategory": "",
+            "header": null,
+            "footer": null,
+            "hidden": null,
+            "action": "list",
+            "orderBy": null,
+            "showLink": {
+                "edit": 1,
+                "view": 1,
+                "delete": 1
+            },
+            "dataStorageList": null,
+            "downloadModeList": null,
+            "recordsToDisplay": null,
+            "_elements": ["third_level_req"]
+        },
+        "search": {
+            "interaction": null,
+            "displayName": null,
+            "defaultCategory": null,
+            "header": null,
+            "footer": null,
+            "hidden": null,
+            "action": "search"
+        },
+        "add": {
+            "interaction": "",
+            "displayName": "",
+            "defaultCategory": "",
+            "header": null,
+            "footer": null,
+            "hidden": null,
+            "action": "add",
+            "_elements": ["third_level_req"]
+        },
+        "edit": {
+            "interaction": "",
+            "displayName": "",
+            "defaultCategory": "",
+            "header": null,
+            "footer": null,
+            "hidden": "1",
+            "action": "edit",
+            "_elements": ["third_level_req"]
+        },
+        "view": {
+            "interaction": "",
+            "displayName": "",
+            "defaultCategory": "",
+            "header": null,
+            "footer": null,
+            "hidden": "1",
+            "action": "view",
+            "_elements": ["third_level_req"]
+        },
+        "delete": {
+            "interaction": "",
+            "displayName": "",
+            "defaultCategory": "",
+            "header": null,
+            "footer": null,
+            "hidden": "1",
+            "action": "delete",
+            "_elements": ["third_level_req"]
+        }
+    }];
+});

--- a/test/31_3_condition_logic_and_hidden_fields/index.html
+++ b/test/31_3_condition_logic_and_hidden_fields/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="stylesheet" href="../../node_modules/mocha/mocha.css"/>
+    <link rel="stylesheet" href="http://d1c6dfkb81l78v.cloudfront.net/jquery.mobile/1.3.1/jqm.min.css"/>
+    <link rel="stylesheet" href="../../css/testrunner.css"/>
+    
+    <script src="../../node_modules/mocha/mocha.js"></script>
+    <script src="../../node_modules/grunt-mocha/phantomjs/bridge.js"></script>
+    <script src="../../node_modules/chai/chai.js"></script>
+    <script src="http://d1c6dfkb81l78v.cloudfront.net/blink/require/4/require.min.js"></script>
+    <script src="../env-head.js"></script>
+</head>
+<body>
+<div data-role="page" data-url="/">
+    <header data-role="header"></header>
+    <div data-role="content" role="main"></div>
+    <footer data-role="footer"></footer>
+</div>
+<div id="mocha"></div>
+<script>
+    require(['test'], function () {
+        mocha.run();
+    });
+</script>
+</body>
+</html>

--- a/test/31_3_condition_logic_and_hidden_fields/test.js
+++ b/test/31_3_condition_logic_and_hidden_fields/test.js
@@ -27,10 +27,7 @@ define(['BlinkForms', 'BIC'], function (Forms) {
         Forms.off('behavioursExecuted');
       });
 
-      // NOTE- this test suite is cumulative, and will rely on the first
-      // test adding the subform and catching the error.
       test('the `behavioursExecuted` is still emitted', function (done) {
-
         Forms.on('behavioursExecuted', function () {
             done();
         });

--- a/test/31_3_condition_logic_and_hidden_fields/test.js
+++ b/test/31_3_condition_logic_and_hidden_fields/test.js
@@ -1,0 +1,55 @@
+define(['BlinkForms', 'BIC'], function (Forms) {
+  suite('31.3 behaviors still work when fields are hidden in a subform', function () {
+    var $page, $content;
+    suiteSetup(function () {
+      /* eslint-disable no-unused-expressions */
+      Forms.current && Forms.current.off();
+      delete Forms.current;
+      $content && $content.empty();
+      /* eslint-enable no-unused-expressions */
+
+      $page = $('[data-role=page]');
+      $content = $page.find('[data-role=content]');
+
+      return Forms.getDefinition('firstLevel', 'add').then(function (def) {
+        Forms.initialize(def);
+
+        $content.append(Forms.current.$form);
+        $.mobile.page({}, $page);
+        $page.trigger('pagecreate');
+        $page.show();
+      });
+    });
+
+    suite('when a field is hidden and it throws an error on subform creation', function () {
+      teardown(function () {
+        // release any behavior listeners
+        Forms.off('behavioursExecuted');
+      });
+
+      // NOTE- this test suite is cumulative, and will rely on the first
+      // test adding the subform and catching the error.
+      test('the `behavioursExecuted` is still emitted', function (done) {
+
+        Forms.on('behavioursExecuted', function () {
+            done();
+        });
+        // you will see a console error because as per feedback, the error is
+        // left in to notify the forms developer that the behaivors and subform
+        // configurtation should probably be re-done
+        Forms.current.getElement('second_level_test').add();
+      });
+
+      test('other field behaviors still work', function (done) {
+        Forms.on('behavioursExecuted', function () {
+          assert.isTrue(Forms.current.getElement('second_level_text').get('hidden'));
+
+          done();
+        });
+
+        assert.isFalse(Forms.current.getElement('second_level_text').get('hidden'));
+        Forms.current.getElement('trigger_field').val('b');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Cherry picked the original commits from https://github.com/blinkmobile/forms/pull/12 because of merge errors, then added:
- Sub form fields will apply the `hide` field and remove the element from the form it will be displaying
  - attempted to cache this result however this lead to many tests failing. It might be worth adding another ticket for caching of subform definitions
- behaviors check for removed element and warn in the console. They return 'undefined' so that the `behavioursExecuted` still executes (keeps backward compatibility with how FORMS3 currently works)
  - might be worth investigating removing any behaviors that reference the removed element
- add documentation for console warnings that explain why the new warning appears.
- removed checking of the `hide` attribute in model
  - regenerated 30_subforms_inside_subforms definition from blinkm.co
  - fixed tests to use different element names and to use the `subFormModel#add()` function
