### PR TITLE
FORMS-203 # avoid re-rendering same error output

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,6 +66,7 @@ module.exports = function (grunt) {
             '@blinkmobile/jqpromise': 'node_modules/@blinkmobile/jqpromise/dist/index',
             '@blinkmobile/varied-definition': 'node_modules/@blinkmobile/varied-definition/dist/index',
             'typed-errors': 'node_modules/js-typed-errors/dist/typed-errors',
+            'classnames': 'node_modules/classnames/index',
             moment: 'node_modules/moment/min/moment.min',
             picker: 'node_modules/pickadate/lib/picker',
             'picker.date': 'node_modules/pickadate/lib/picker.date',

--- a/forms/jqm/templates/bm-list.html
+++ b/forms/jqm/templates/bm-list.html
@@ -1,0 +1,5 @@
+<ul>
+  <% items.forEach(function (item) { %>
+  <li class="<%= item.class %>"><%= item.text %></li>
+  <% }); %>
+</ul>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@blinkmobile/varied-definition": "1.0.0",
     "amd-feature": "jensarps/AMD-feature#v1.2.1",
     "blinkgap-utils": "git://github.com/blinkmobile/blinkgap-utils#500774457d",
+    "classnames": "^2.1.3",
     "js-typed-errors": "simonmarklar/js-typed-errors#21bd090",
     "moment": "2.10.3",
     "node-uuid": "1.4.3",


### PR DESCRIPTION
- only delete the `.bm-errors__bm-list` DOM element if we aren't going to need it (no errors)
- only append a new `.bm-errors__bm-list` DOM element if we don't have one and we need one
- only re-append an existing `.bm-errors__bm-list` DOM element if ours isn't already beneath the input fields (this was technically happening already, this PR just makes this explicit)
- use an Underscore template to generate the `.bm-errors__bm-listitem` DOM elements
- compare the prospective output against what's already in the DOM, and only update the DOM if there's a difference
## results: iPad 2 with iOS 7.1
- still a visible pause / freeze whenever the validation message needs to be updated or removed
- no longer any noticeable freeze if current validation message still applies (e.g. continuing to type past the maximum length)
- no longer any noticeable freeze if no validation message and none needed for new output (e.g. continuing to type valid data)
- these results do not include the event debouncing changes in the other PR
