### PR TITLE
FORMS-203 # avoid double `#initializeView()`

### DIFF
--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -81,9 +81,8 @@ define(function (require) {
         this.setDirty();
       }, this);
       this.on('remove', this.close, this);
-
-      this.initializeView();
     },
+
     validate: function (attrs) {
       var errors = {};
 

--- a/forms/models/elements/date.js
+++ b/forms/models/elements/date.js
@@ -5,6 +5,18 @@ define([
   'use strict';
 
   var DateElement = Element.extend({
+
+    defaults: {
+      page: 0,
+      class: '',
+      defaultValue: '',
+      value: '',
+      _time: '',
+      _date: '',
+      hidden: false,
+      persist: true
+    },
+
     initialize: function () {
       var attr = this.attributes;
       var dateFormat;
@@ -113,6 +125,7 @@ define([
       }
       this.set('_view', view);
     },
+
     /**
      * update value to match _date and/or _time
      */
@@ -137,12 +150,13 @@ define([
         this.set('value', date + 'T' + time);
       }
     },
+
     /**
      * update _date and/or _time to match value
      */
     prepareDateTime: function () {
       var type = this.attributes.type;
-      var value = this.attributes.value;
+      var value = this.attributes.value || '';
       var time;
       var date;
       var parts;


### PR DESCRIPTION
- ElementModel was originally hitting `#initializeView()` in its constructor
- since this happens later anyway, we don't need to do this here
- fix DateModel now that it can't depend on an early View
## results: Chrome on MacBook Pro R-15 2012
- form initialisation (test/27_performance) from 4047ms down to 1750ms
## results: Nexus 7 2012
- form initialisation (test/27_performance) from 80457ms down to 31668ms
