### PR TITLE
(refactor) REQUIRED validation shares more code

### DIFF
--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -83,6 +83,14 @@ define(function (require) {
       this.on('remove', this.close, this);
     },
 
+    isEmpty: function () {
+      var value = this.attributes.value;
+      if (Array.isArray(value)) {
+        return !value.length;
+      }
+      return !value && value !== 0;
+    },
+
     validate: function (attrs) {
       var errors = {};
 
@@ -95,7 +103,7 @@ define(function (require) {
         return undefined;
       }
 
-      if (attrs.required && !attrs.value) {
+      if (attrs.required && this.isEmpty()) {
         errors.value = errors.value || [];
         errors.value.push({code: 'REQUIRED'});
 

--- a/forms/models/elements/file.js
+++ b/forms/models/elements/file.js
@@ -112,14 +112,8 @@ define(function (require) {
 /**
 override because super#validate() checks "value", and we need to check "blob"
 */
-    validate: function (attrs) {
-      var errors = {};
-      attrs = attrs || this.attributes;
-      if (attrs.required && !attrs.blob) {
-        errors.value = errors.value || [];
-        errors.value.push({code: 'REQUIRED'});
-      }
-      return _.isEmpty(errors) ? undefined : errors;
+    isEmpty: function () {
+      return !this.attributes.blob;
     },
 
 /**

--- a/forms/models/elements/multi.js
+++ b/forms/models/elements/multi.js
@@ -7,6 +7,7 @@ define(function (require) {
 
   // local modules
 
+  var Element = require('forms/models/element');
   var SelectElement = require('forms/models/elements/select');
 
   // this module
@@ -23,6 +24,7 @@ define(function (require) {
         delete attrs.canSpecifyOther;
       }
     },
+
     initializeView: function () {
       var Forms = BMP.Forms;
       var View, view, mode;
@@ -41,24 +43,16 @@ define(function (require) {
       this.set('_view', view);
       return view;
     },
-    validate: function (attrs) {
-      var errors = {};
-      if (attrs === undefined) {
-        attrs = this.attributes;
-      }
 
-      // if `other` is true
-      // and required is true
-      // and attr.lenghth === 1 && _.contains(attr.value, 'other')
-      // and other is not in options
-      // then fail
-      if (attrs.required && (_.isEmpty(attrs.value) || attrs.other && (attrs.value.length === 1 && attrs.value[0] === 'other') && !_.contains(attrs.options, 'other'))) {
-        errors.value = errors.value || [];
-        errors.value.push({code: 'REQUIRED'});
+    isEmpty: function () {
+      var attrs = this.attributes;
+      // skip super's and go straight to super-super's isEmpty
+      if (Element.prototype.isEmpty.call(this)) {
+        return true;
       }
-
-      return _.isEmpty(errors) ? undefined : errors;
+      return attrs.other && _.isEqual(attrs.value, ['other']) && !_.contains(attrs.options, 'other');
     }
+
   });
 
   return MultiElement;

--- a/forms/models/elements/select.js
+++ b/forms/models/elements/select.js
@@ -48,23 +48,14 @@ define(function (require) {
       this.set('_view', view);
       return view;
     },
-    validate: function (attrs) {
-      var errors = {};
-      if (attrs === undefined) {
-        attrs = this.attributes;
-      }
 
-      // if `other` is true
-      // and required is true
-      // and attr.value === 'other'
-      // and other is not in options
-      // then fail
-      if (attrs.required && (!attrs.value || attrs.other && attrs.value === 'other' && !_.contains(attrs.options, 'other'))) {
-        errors.value = errors.value || [];
-        errors.value.push({code: 'REQUIRED'});
+    isEmpty: function () {
+      var attrs = this.attributes;
+      if (Element.prototype.isEmpty.call(this)) {
+        return true;
       }
-
-      return _.isEmpty(errors) ? undefined : errors;
+      return attrs.other && attrs.value === 'other' && !_.contains(attrs.options, 'other');
     }
+
   });
 });


### PR DESCRIPTION
This is the last of the safe changes to cherry-pick from https://github.com/blinkmobile/forms/pull/15
- the Elements that need to customise their REQUIRED validation now simply declare an `#isEmpty()` method, instead of various very-similar implementations of `#validate()`
