### PR TITLE
FORMS-221 # remove subform from EDIT interaction and you are unable to submit the form

### DIFF
--- a/forms/collections/elements.js
+++ b/forms/collections/elements.js
@@ -29,7 +29,7 @@ define(function (require) {
       errorList = elementModel.get('forms').reduce(function (errList, form) {
         elements = form.get('elements');
         if (!elements) {
-          return [];
+          return errList;
         }
         return elements.reduce(addToErrorList, errList);
       }, errorList);

--- a/forms/collections/elements.js
+++ b/forms/collections/elements.js
@@ -18,6 +18,7 @@ define(function (require) {
 
   function addToErrorList (errorList, elementModel) {
     var err;
+    var elements;
     if (!_.isEmpty(elementModel.validationError)) {
       err = {};
       err[ elementModel.get('name') ] = _.map(elementModel.validationError.value, addErrorText);
@@ -26,7 +27,11 @@ define(function (require) {
 
     if (elementModel.get('forms')) {
       errorList = elementModel.get('forms').reduce(function (errList, form) {
-        return form.get('elements').reduce(addToErrorList, errList);
+        elements = form.get('elements');
+        if (!elements) {
+          return [];
+        }
+        return elements.reduce(addToErrorList, errList);
       }, errorList);
     }
 

--- a/forms/models/form.js
+++ b/forms/models/form.js
@@ -24,10 +24,21 @@ define(function (require) {
 
   invalidWrapperFn = function (fn) {
     return function (options) {
-      var elementCollection = new Elements(this.get('elements').filter(isVisible));
-      var validate = options && options.validate || false;
-      var limit = options && options.limit || 0;
+      var elementCollection;
+      var validate;
+      var limit;
       var results;
+      var elements;
+
+      elements = this.get('elements');
+
+      if (!elements) {
+        return undefined;
+      }
+
+      elementCollection = new Elements(elements.filter(isVisible));
+      validate = options && options.validate || false;
+      limit = options && options.limit || 0;
 
       if (!elementCollection) {
         return undefined;

--- a/test/25_preloadSubform/test.js
+++ b/test/25_preloadSubform/test.js
@@ -317,6 +317,25 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
           });
         });
 
+        test("test getErrors", function () {
+          try {
+            Forms.current.getErrors();
+            assert(true);
+          } catch (e) {
+            console.log(e);
+            assert(false, 'throws error');
+          }
+        });
+
+        test("test getInvalidElements", function () {
+          try {
+            Forms.current.getInvalidElements();
+            assert(true);
+          } catch (e) {
+            assert(false, e);
+          }
+        });
+
       });
 
     }); // END: suite('Form', ...)


### PR DESCRIPTION
- when removing existing subform record (one with id), it replaces form object with placeholder object containing _action and id
  -- when addToErrorList/invalidWrapperFn tries to get elements, those object won't have any
- added checks to see if model actually returns elements before doing anything with it.
- tests to confirm those functions are not throwing any errors
