### PR TITLE
FORMS-200 # Date model value doesn't propagate to pickadate modal picker

### DIFF
--- a/forms/jqm/elements/date.js
+++ b/forms/jqm/elements/date.js
@@ -5,6 +5,7 @@ define(function (require) {
 
   var $ = require('jquery');
   var _ = require('underscore');
+  var moment = require('moment');
 
   // local modules
 
@@ -83,7 +84,13 @@ define(function (require) {
     },
 
     onDateVChange: function (event) {
-      this.model.set('_date', $(event.target).val());
+      var dateFormat = this.model.mapDateFormats[this.model.attributes.dateFormat] || 'YYYY-MM-DD';
+      var value = $(event.target).val();
+
+      if (value) {
+        value = moment($(event.target).val(), dateFormat).format('YYYY-MM-DD');
+      }
+      this.model.set('_date', value);
     },
 
     onTimeVChange: function (event) {
@@ -92,7 +99,31 @@ define(function (require) {
 
     onDateMChange: function () {
       var name = this.model.attributes.name;
-      this.$el.find('input[name="' + name + '_date"]').val(this.model.get('_date'));
+      var value = this.model.get('_date');
+      var input = this.$el.find('input[name="' + name + '_date"]');
+      var picker = input.pickadate('picker');
+      var pickerValue;
+      var dateFormat = this.model.mapDateFormats[this.model.get('dateFormat')] || 'YYYY-MM-DD';
+
+      if (picker) {
+        pickerValue = picker.get('select', 'yyyy-mm-dd');
+      }
+
+      if (value !== pickerValue) {
+        if (picker) {
+          if (!value || value === '0000-00-00') {
+            picker.set('clear');
+          } else {
+            picker.set('select', value, {format: 'yyyy-mm-dd'});
+          }
+        } else {
+          if (this.model.attributes.nativeDatePicker) {
+            input.val(value);
+          } else {
+            input.val(moment(Date.parse(value)).format(dateFormat));
+          }
+        }
+      }
     },
 
     onTimeMChange: function () {

--- a/forms/jqm/elements/date.js
+++ b/forms/jqm/elements/date.js
@@ -7,6 +7,11 @@ define(function (require) {
   var _ = require('underscore');
   var moment = require('moment');
 
+  // variables
+
+  var DEFAULT_FORMAT = 'YYYY-MM-DD';
+  var PICKER_FORMAT = 'yyyy-mm-dd';
+
   // local modules
 
   var ElementView = require('forms/jqm/element');
@@ -84,8 +89,7 @@ define(function (require) {
     },
 
     onDateVChange: function (event) {
-      var defaultFormat = 'YYYY-MM-DD';
-      var dateFormat = this.model.mapDateFormats[this.model.attributes.dateFormat] || defaultFormat;
+      var dateFormat = this.model.mapDateFormats[this.model.attributes.dateFormat] || DEFAULT_FORMAT;
       var value = $(event.target).val();
 
       try {
@@ -95,7 +99,7 @@ define(function (require) {
         return;
       }
       if (value) {
-        value = moment(value, dateFormat).format('YYYY-MM-DD');
+        value = moment(value, dateFormat).format(DEFAULT_FORMAT);
       }
       this.model.set('_date', value);
     },
@@ -110,19 +114,17 @@ define(function (require) {
       var input = this.$el.find('input[name="' + name + '_date"]');
       var picker = input.pickadate('picker');
       var pickerValue;
-      var defaultFormat = 'YYYY-MM-DD';
-      var pickerFormat = 'yyyy-mm-dd';
-      var dateFormat = this.model.mapDateFormats[this.model.get('dateFormat')] || defaultFormat;
+      var dateFormat = this.model.mapDateFormats[this.model.get('dateFormat')] || DEFAULT_FORMAT;
 
       try {
-        this.model.isInvalidFormat(defaultFormat, value);
+        this.model.isInvalidFormat(DEFAULT_FORMAT, value);
       } catch (err) {
         window.console.log(err);
         return;
       }
 
       if (picker) {
-        pickerValue = picker.get('select', pickerFormat);
+        pickerValue = picker.get('select', PICKER_FORMAT);
       }
 
       if (value !== pickerValue) {
@@ -130,7 +132,7 @@ define(function (require) {
           if (!value || value === '0000-00-00') {
             picker.set('clear');
           } else {
-            picker.set('select', value, {format: pickerFormat});
+            picker.set('select', value, {format: PICKER_FORMAT});
           }
         } else {
           if (this.model.attributes.nativeDatePicker) { // for native picker

--- a/forms/jqm/elements/date.js
+++ b/forms/jqm/elements/date.js
@@ -87,8 +87,14 @@ define(function (require) {
       var dateFormat = this.model.mapDateFormats[this.model.attributes.dateFormat] || 'YYYY-MM-DD';
       var value = $(event.target).val();
 
+      try {
+        this.model.isInvalidFormat(dateFormat, value);
+      } catch (err) {
+        window.console.log(err);
+        return;
+      }
       if (value) {
-        value = moment($(event.target).val(), dateFormat).format('YYYY-MM-DD');
+        value = moment(value, dateFormat).format('YYYY-MM-DD');
       }
       this.model.set('_date', value);
     },
@@ -105,6 +111,13 @@ define(function (require) {
       var pickerValue;
       var dateFormat = this.model.mapDateFormats[this.model.get('dateFormat')] || 'YYYY-MM-DD';
 
+      try {
+        this.model.isInvalidFormat('YYYY-MM-DD', value);
+      } catch (err) {
+        window.console.log(err);
+        return;
+      }
+
       if (picker) {
         pickerValue = picker.get('select', 'yyyy-mm-dd');
       }
@@ -117,10 +130,12 @@ define(function (require) {
             picker.set('select', value, {format: 'yyyy-mm-dd'});
           }
         } else {
-          if (this.model.attributes.nativeDatePicker) {
+          if (this.model.attributes.nativeDatePicker) { //for native picker
             input.val(value);
           } else {
-            input.val(moment(Date.parse(value)).format(dateFormat));
+            if (value) { // for default value when picker not initialised
+              input.val(moment(Date.parse(value)).format(dateFormat));
+            }
           }
         }
       }

--- a/forms/jqm/elements/date.js
+++ b/forms/jqm/elements/date.js
@@ -80,7 +80,13 @@ define(function (require) {
 
     onDateMChange: function () {
       var name = this.model.attributes.name;
+      var input, picker;
       this.$el.find('input[name=' + name + '_date]').val(this.model.get('_date'));
+      input = this.$el.find('input[name=' + name + '_date]');
+      picker = input.pickadate('picker');
+      if (picker) {
+        picker.set('select', new Date(this.model.get('_date')));
+      }
     },
 
     onTimeMChange: function () {

--- a/forms/jqm/elements/date.js
+++ b/forms/jqm/elements/date.js
@@ -84,7 +84,8 @@ define(function (require) {
     },
 
     onDateVChange: function (event) {
-      var dateFormat = this.model.mapDateFormats[this.model.attributes.dateFormat] || 'YYYY-MM-DD';
+      var defaultFormat = 'YYYY-MM-DD';
+      var dateFormat = this.model.mapDateFormats[this.model.attributes.dateFormat] || defaultFormat;
       var value = $(event.target).val();
 
       try {
@@ -109,17 +110,19 @@ define(function (require) {
       var input = this.$el.find('input[name="' + name + '_date"]');
       var picker = input.pickadate('picker');
       var pickerValue;
-      var dateFormat = this.model.mapDateFormats[this.model.get('dateFormat')] || 'YYYY-MM-DD';
+      var defaultFormat = 'YYYY-MM-DD';
+      var pickerFormat = 'yyyy-mm-dd';
+      var dateFormat = this.model.mapDateFormats[this.model.get('dateFormat')] || defaultFormat;
 
       try {
-        this.model.isInvalidFormat('YYYY-MM-DD', value);
+        this.model.isInvalidFormat(defaultFormat, value);
       } catch (err) {
         window.console.log(err);
         return;
       }
 
       if (picker) {
-        pickerValue = picker.get('select', 'yyyy-mm-dd');
+        pickerValue = picker.get('select', pickerFormat);
       }
 
       if (value !== pickerValue) {
@@ -127,7 +130,7 @@ define(function (require) {
           if (!value || value === '0000-00-00') {
             picker.set('clear');
           } else {
-            picker.set('select', value, {format: 'yyyy-mm-dd'});
+            picker.set('select', value, {format: pickerFormat});
           }
         } else {
           if (this.model.attributes.nativeDatePicker) { // for native picker

--- a/forms/models/elements/date.js
+++ b/forms/models/elements/date.js
@@ -19,7 +19,7 @@ define([
 
     initialize: function () {
       var attr = this.attributes;
-      var dateFormat;
+      var dateFormat = 'YYYY-MM-DD';
       var timeFormat;
       var dateValue = null;
       var timeValue = null;
@@ -62,7 +62,6 @@ define([
       if (attr.defaultValue) {
         switch (attr.type) {
           case 'date':
-            dateFormat = 'YYYY-MM-DD';
             if (attr.defaultValue === 'now') {
               dateValue = moment();
             } else if (attr.defaultValue === 'now_plus') {
@@ -86,7 +85,6 @@ define([
             }
             break;
           case 'datetime':
-            dateFormat = 'YYYY-MM-DD';
             timeFormat = this.mapTimeFormats[attr.timeFormat] || 'HH:mm';
             if (attr.defaultValue === 'now') {
               timeValue = dateValue = moment();
@@ -200,6 +198,15 @@ define([
       // type === 'datetime'
       return new Date(this.attributes._date + 'T' + this.attributes._time);
     },
+
+    isInvalidFormat: function (dateFormat, value) {
+      var formats = [dateFormat];
+
+      if (value && value !== '0000-00-00' && !moment(value, [dateFormat], true).isValid()) {
+        throw new Error(this.attributes.name + ' expect value in format ' + dateFormat);
+      }
+    },
+
     mapDateFormats: {
       yyyy_mm_dd: 'YYYY-MM-DD',
       mm_dd_yyyy: 'MM-DD-YYYY',

--- a/forms/models/elements/date.js
+++ b/forms/models/elements/date.js
@@ -62,7 +62,7 @@ define([
       if (attr.defaultValue) {
         switch (attr.type) {
           case 'date':
-            dateFormat = this.mapDateFormats[attr.dateFormat] || 'YYYY-MM-DD';
+            dateFormat = 'YYYY-MM-DD';
             if (attr.defaultValue === 'now') {
               dateValue = moment();
             } else if (attr.defaultValue === 'now_plus') {
@@ -86,7 +86,7 @@ define([
             }
             break;
           case 'datetime':
-            dateFormat = this.mapDateFormats[attr.dateFormat] || 'YYYY-MM-DD';
+            dateFormat = 'YYYY-MM-DD';
             timeFormat = this.mapTimeFormats[attr.timeFormat] || 'HH:mm';
             if (attr.defaultValue === 'now') {
               timeValue = dateValue = moment();

--- a/test/1_date_time/test.js
+++ b/test/1_date_time/test.js
@@ -346,7 +346,7 @@ define(['BlinkForms', 'testUtils', 'underscore', 'moment', 'BIC'], function (For
           'dateTimePckerNowPM'
         ];
 
-        test('check element value assignment reflected in picker, model, view ', function (done) {
+        test('element value assignment reflected in picker, model, view ', function (done) {
           setTimeout(function () {
               pickadate.forEach(function (fld) {
                 var form = Forms.current;
@@ -375,7 +375,11 @@ define(['BlinkForms', 'testUtils', 'underscore', 'moment', 'BIC'], function (For
 
                   assert.equal(date$.val(), expected, fld + ': DOM date value');
                   assert.equal(el.get('_date'), date, fld + ': _date value');
-                  assert.equal(el.val().split('T')[0], el.get('_date'), fld + ': element value');
+                  if (type === 'datetime') {
+                    assert.equal(el.val().split('T')[0], el.get('_date'), fld + ': element value');
+                  } else {
+                    assert.equal(el.val(), el.get('_date'), fld + ': element value');
+                  }
                   if (picker) {
                     assert.equal(picker.get('select', 'yyyy-mm-dd'), el.get('_date'), fld + ': picker value');
                   }

--- a/test/1_date_time/test.js
+++ b/test/1_date_time/test.js
@@ -1,4 +1,4 @@
-define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
+define(['BlinkForms', 'testUtils', 'underscore', 'moment', 'BIC'], function (Forms, testUtils, _, moment) {
 
   var nativedate = [
     'date',
@@ -29,7 +29,7 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
           var time = el.get('_time');
           var date = el.get('_date');
           var type = el.get('type');
-          var time$, date$;
+          var time$, date$, format;
           if (type === 'hidden') {
             return;
           }
@@ -37,8 +37,11 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
           date$ = el.get('_view').$el.find('input[name$=_date]');
           if (value && !el.get('readonly')) {
             if (type !== 'time') {
+              format = el.mapDateFormats[el.attributes.dateFormat] || 'YYYY-MM-DD';
               assert.lengthOf(date$, 1, name + ': has DOM date');
-              assert.equal(date$.val(), date, name + ': DOM date value');
+              if (date$.val() && date) {
+                assert.equal(date$.val(), moment(date, 'YYYY-MM-DD').format(format), name + ': DOM date value');
+              }
             }
             if (type !== 'date') {
               assert.lengthOf(time$, 1, name + ': has DOM time');
@@ -60,7 +63,13 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
           var value = el.val();
           var name = el.get('name');
           var type = el.get('type');
-          var time$, date$;
+          var time$, date$, format, result;
+          var nowdate = [
+            'datenow',
+            'datefromnowplus',
+            'dateTimeHiddenNow'
+          ];
+
           if (type === 'hidden') {
             return;
           }
@@ -68,12 +77,20 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
           date$ = el.get('_view').$el.find('input[name$=_date]');
           if (value && !el.get('readonly')) {
             if (type !== 'time') {
-              date = "2015-06-10";
-              date$.val(date);
+              format = el.mapDateFormats[el.attributes.dateFormat] || 'YYYY-MM-DD';
+              if (_.indexOf(nowdate, name) > -1) {
+                date = moment().format('YYYY-MM-DD');
+              } else if (name === 'datefromdate') {
+                date = '2014-03-10';
+              } else {
+                date = "2015-06-10";
+              }
+              result = moment(date).format(format);
+              date$.val(result);
               date$.trigger('change');
               assert.lengthOf(date$, 1, name + ': has DOM date');
-              assert.equal(date$.val(), date, name + ': DOM date value');
-              assert.equal(date$.val(), el.get('_date'), name + ': _date value');
+              assert.equal(date$.val(), result, name + ': DOM date value');
+              assert.equal(date, el.get('_date'), name + ': _date value');
             }
             if (type !== 'date') {
               time = "10:00";
@@ -309,6 +326,64 @@ define(['BlinkForms', 'testUtils', 'BIC'], function (Forms, testUtils) {
 
         defineModelToViewTests();
         defineViewToModelTests();
+      });
+
+      suite('picker value assignment', function () {
+        var pickadate = [
+          'datenonative',
+          'datetimenonative',
+          'datenow',
+          'datefromnowplus',
+          'datefromdate',
+          'datetimenow',
+          'dateTimeHiddenNone',
+          'dateTimeHiddenNow',
+          'dateTimeHiddenNowP',
+          'dateTimeHddenNowPM',
+          'dateTimePickerNone',
+          'dateTimePickerNow',
+          'dateTimePickerNowP',
+          'dateTimePckerNowPM'
+        ];
+
+        test('check element value assignment reflected in picker, model, view ', function (done) {
+          setTimeout(function () {
+              pickadate.forEach(function (fld) {
+                var form = Forms.current;
+                var el = form.getElement(fld);
+                var type = el.get('type');
+                var nowdate = [
+                  'datenow',
+                  'datefromnowplus',
+                  'dateTimeHiddenNow'
+                ];
+                var date$ = el.get('_view').$el.find('input[name$=_date]');
+                var picker = date$.pickadate('picker');
+                var dateFormat = el.mapDateFormats[el.attributes.dateFormat] || "YYYY-MM-DD";
+                var expected, date;
+
+                if (type !== 'time') {
+                  if (_.indexOf(nowdate, fld) > -1) {
+                    date = moment().format('YYYY-MM-DD');
+                  } else if (fld === 'datefromdate') {
+                    date = '2014-03-10';
+                  } else {
+                    date = "2015-06-10";
+                  }
+                  el.val(date);
+                  expected = moment(date).format(dateFormat);
+
+                  assert.equal(date$.val(), expected, fld + ': DOM date value');
+                  assert.equal(el.get('_date'), date, fld + ': _date value');
+                  assert.equal(el.val().split('T')[0], el.get('_date'), fld + ': element value');
+                  if (picker) {
+                    assert.equal(picker.get('select', 'yyyy-mm-dd'), el.get('_date'), fld + ': picker value');
+                  }
+                }
+              });
+              done();
+            }, 1e3);
+        });
       });
 
     }); // END: suite('Form', ...)

--- a/test/env-head.js
+++ b/test/env-head.js
@@ -25,7 +25,7 @@
       picker: '../../node_modules/pickadate/lib/picker',
       'picker.date': '../../node_modules/pickadate/lib/picker.date',
       'picker.time': '../../node_modules/pickadate/lib/picker.time',
-      'moment': '../../node_modules/momentjs/min/moment.min',
+      moment: '../../node_modules/moment/min/moment.min',
       bluebird: '../../node_modules/bluebird/js/browser/bluebird.min',
       feature: '../../node_modules/amd-feature/feature',
       'es5-shim': '../../node_modules/es5-shim/es5-shim.min',

--- a/test/sample-bic.js
+++ b/test/sample-bic.js
@@ -6,13 +6,14 @@ define([
   'feature!promises',
   'jquery',
   'underscore',
+  'moment',
   'BlinkForms',
   'definitions',
   'BMP.Blob',
   'BMP.BlinkGap',
   'feature!es5',
   'jquerymobile'
-], function (Promise, $, _, Forms, defs) {
+], function (Promise, $, _, moment, Forms, defs) {
   'use strict';
 
   var $submitPopup, $footer, $grid, $colB;


### PR DESCRIPTION
- element.val() will be reflected in picker
- element.val('2015-10-02') should use ISO 8601 format
- input.val() will be using date element format or default format i.e ISO 8601
- error will be thrown in case invalid format is used
