### PR TITLE
FORMS-229 # fix REQUIRED validation messages for date/time

### DIFF
--- a/forms/jqm/element.js
+++ b/forms/jqm/element.js
@@ -179,6 +179,10 @@ define(function (require) {
       var list$ = this.$el.children('.bm-errors__bm-list');
       var new$;
 
+      if (!attrs) {
+        return; // not safe to run yet
+      }
+
       if (!errors || !errors.value || !errors.value.length) {
         this.$el.children('.bm-errors__bm-list').remove();
         this.onInvalidChange();

--- a/forms/jqm/element.js
+++ b/forms/jqm/element.js
@@ -55,7 +55,7 @@ define(function (require) {
     },
 
     modelEvents: {
-      'invalid change:value': 'renderErrors',
+      'invalid valid': 'renderErrors',
       'change:hidden': 'onChangeHidden',
       'change:label': 'renderLabel',
       'change:isDirty': 'onDirtyChange',

--- a/forms/jqm/elements/date.js
+++ b/forms/jqm/elements/date.js
@@ -27,7 +27,7 @@ define(function (require) {
     // extending super's modelEvents
     modelEvents: _.extend({}, ElementView.prototype.modelEvents, {
       'change:_date': 'onDateMChange',
-      'change:_time': 'onDateMChange'
+      'change:_time': 'onTimeMChange'
     }),
 
     renderDate: function () {

--- a/forms/jqm/elements/subform.js
+++ b/forms/jqm/elements/subform.js
@@ -25,7 +25,7 @@ define(function (require) {
     remove: function () {
       this.$el.children('.ui-btn').children('button').off('click');
       this.model.attributes.forms.off('change', this.onFormsChange, this);
-      this.stopListening(this.model, 'invalid change:value change:blob');
+      this.stopListening(this.model, 'invalid valid');
       this.model.attributes.forms.forEach(function (form) {
         form.get('_view').remove();
       });

--- a/forms/mixins/model-validation.js
+++ b/forms/mixins/model-validation.js
@@ -1,0 +1,28 @@
+define(function (require) {
+  'use strict';
+
+  // foreign modules
+
+  var Backbone = require('backbone');
+
+  // this module
+
+  return {
+
+    /**
+    intended to replace `Backbone.Model#isValid`
+    @param {Object} [options]
+    @fires invalid
+    @fires valid
+    @returns {boolean}
+    */
+    isValid: function (options) {
+      var result = Backbone.Model.prototype.isValid.call(this, options);
+      if (result) {
+        this.trigger('valid', this);
+      }
+      return result;
+    }
+
+  };
+});

--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -14,7 +14,9 @@ define(function (require) {
   var Backbone = require('backbone');
 
   // local modules
+
   var modelStates = require('forms/mixins/model-states-mixin');
+  var modelValidation = require('forms/mixins/model-validation');
 
   // this module
 
@@ -74,7 +76,7 @@ define(function (require) {
       }
 
       // backward compatability.
-      this.on('invalid change:value', this.updateErrors, this);
+      this.on('invalid valid', this.updateErrors, this);
 
       this.on('change:value', function () {
         this.setDirty();
@@ -89,6 +91,8 @@ define(function (require) {
       }
       return !value && value !== 0;
     },
+
+    isValid: modelValidation.isValid,
 
     validate: function (attrs) {
       var errors = {};

--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -1,3 +1,4 @@
+/* eslint-disable accessor-pairs */ // we're using the "set" keyword for method
 /**
  * Element Model Module
  *
@@ -221,24 +222,46 @@ define(function (require) {
       this.set('_view', view);
       return view;
     },
+
+    /**
+    @override
+    */
+    set: function (key, value, options) {
+      var attrs, result;
+      if (!key) {
+        return;
+      }
+
+      if (typeof key === 'object') {
+        // `#set(attributes, options)`
+        attrs = key;
+        options = value;
+      } else {
+        // `#set(key, value, options)`
+        attrs = {};
+        attrs[key] = value;
+      }
+
+      result = Backbone.Model.prototype.set.call(this, attrs, options);
+
+      if ('value' in attrs) {
+        if (!options || !options.hasOwnProperty('value') || options.validate) {
+          this.isValid();
+        }
+      }
+
+      return result;
+    },
+
     /**
      * official Blink API
      */
     val: function (value) {
-      var attrs;
-
       if (value === undefined) {
         return this.get('value');
       }
 
-      attrs = _.extend({}, this.attributes, {value: value});
-      this.validationError = this.validate(attrs);
-      if (this.validationError) {
-        this.trigger('invalid', this, this.validationError);
-      }
-
-      this.set('value', value, {validate: false});
-
+      this.set('value', value);
       return value;
     }
   }, {

--- a/forms/models/elements/date.js
+++ b/forms/models/elements/date.js
@@ -128,16 +128,18 @@ define([
      * update value to match _date and/or _time
      */
     prepareValue: function () {
-      var type = this.attributes.type;
+      var attrs = this.attributes;
+      var type = attrs.type;
       var date;
       var time;
+
       if (type === 'date') {
-        this.set('value', this.attributes._date);
+        this.set('value', attrs._date);
       } else if (type === 'time') {
-        this.set('value', this.attributes._time);
+        this.set('value', attrs._time);
       } else { // type === 'datetime'
-        date = this.attributes._date;
-        time = this.attributes._time;
+        date = attrs._date;
+        time = attrs._time;
         // TODO: somehow stop this from firing twice
         if (!date) {
           date = '0000-00-00';
@@ -153,8 +155,9 @@ define([
      * update _date and/or _time to match value
      */
     prepareDateTime: function () {
-      var type = this.attributes.type;
-      var value = this.attributes.value || '';
+      var attrs = this.attributes;
+      var type = attrs.type;
+      var value = attrs.value || '';
       var time;
       var date;
       var parts;
@@ -164,8 +167,8 @@ define([
       } else if (type === 'time') {
         this.set('_time', value);
       } else { // type === 'datetime'
-        time = this.attributes._time;
-        date = this.attributes._date;
+        time = attrs._time;
+        date = attrs._date;
         parts = value.split('T');
         if (parts[0]) {
           this.set('_date', parts[0], {silent: true});
@@ -173,10 +176,10 @@ define([
         if (parts[1]) {
           this.set('_time', parts[1], {silent: true});
         }
-        if (time !== this.attributes._time) {
+        if (time !== attrs._time) {
           this.trigger('change:_time');
         }
-        if (date !== this.attributes._date) {
+        if (date !== attrs._date) {
           this.trigger('change:_date');
         }
       }

--- a/forms/models/elements/subform.js
+++ b/forms/models/elements/subform.js
@@ -95,8 +95,8 @@ define(function (require) {
         attrs.summaryPromise = this.getSummaryElements();
       }
 
-      this.attributes.forms.on('add remove invalid change:value change:blob', this.updateFieldErrors, this);
-      this.off('invalid change:value change:blob');
+      this.attributes.forms.on('add remove invalid valid', this.updateFieldErrors, this);
+      this.off('invalid valid');
 
       // make sure that all form events are bubbled up through this subform
       this.attributes.forms.on('all', function () {

--- a/forms/models/form.js
+++ b/forms/models/form.js
@@ -12,6 +12,7 @@ define(function (require) {
   var Elements = require('forms/collections/elements');
   var Pages = require('forms/collections/pages');
   var modelStates = require('forms/mixins/model-states-mixin');
+  var modelValidation = require('forms/mixins/model-validation');
   var isValidFormId = require('forms/helpers/is-valid-form-id');
 
   // this module
@@ -155,6 +156,8 @@ define(function (require) {
         self.trigger('formLoad', self);
       }, 0);
     },
+
+    isValid: modelValidation.isValid,
 
     /**
      * When a form is set to a pristine state, set all its child elements to pristine as well.

--- a/test/1_date_time/test.js
+++ b/test/1_date_time/test.js
@@ -340,5 +340,21 @@ define(['BlinkForms', 'testUtils', 'underscore', 'moment', 'BIC'], function (For
           }, 1e3);
       });
     });
+
+    suite('time assignment', function () {
+      suiteSetup(function () {
+        Forms.current.get('elements').forEach(function (el) {
+          var type = el.get('type');
+          var value = '13:45';
+          if (type !== 'time') {
+            return;
+          }
+          el.val(value);
+        });
+      });
+
+      defineModelToViewTests();
+      defineViewToModelTests();
+    });
   }); // END: suite('Form', ...)
 });

--- a/test/5_validation/definitions.js
+++ b/test/5_validation/definitions.js
@@ -269,6 +269,60 @@ define(function () {
                 g: 'gamma'
               }
             }
+          },
+          {
+            default: {
+              name: 'date',
+              label: 'date',
+              type: 'date',
+              native: false,
+              required: true
+            }
+          },
+          {
+            default: {
+              name: 'datetime',
+              label: 'datetime',
+              type: 'datetime',
+              native: false,
+              required: true
+            }
+          },
+          {
+            default: {
+              name: 'time',
+              label: 'time',
+              type: 'time',
+              native: false,
+              required: true
+            }
+          },
+          {
+            default: {
+              name: 'date_n',
+              label: 'date_n',
+              type: 'date',
+              nativeDatePicker: '1',
+              required: true
+            }
+          },
+          {
+            default: {
+              name: 'datetime_n',
+              label: 'datetime_n',
+              type: 'datetime',
+              nativeTimePicker: '1',
+              required: true
+            }
+          },
+          {
+            default: {
+              name: 'time_n',
+              label: 'time_n',
+              type: 'time',
+              nativeDatetimePicker: '1',
+              required: true
+            }
           }
         ],
         _sections: [

--- a/test/5_validation/test.js
+++ b/test/5_validation/test.js
@@ -333,6 +333,27 @@ define([
         });
       });
 
+      [
+        'date', 'datetime', 'time', 'date_n', 'datetime_n', 'time_n'
+      ].forEach(function (name) {
+        var VALID = {
+          // TODO: finish FORMS-231 and support all ISO8601 formats
+          date: '2015-12-25',
+          datetime: '2015-12-25T12:00:00',
+          time: '12:00:00'
+        };
+
+        test(name + ': required', function () {
+          var element = Forms.current.getElement(name);
+
+          return testUtils.confirmValueIsInvalid(element, '', ['REQUIRED'])
+          .then(function () {
+            var type = element.attributes.type;
+            return testUtils.confirmValueIsValid(element, VALID[type]);
+          });
+        });
+      });
+
       test('validation events are bubbled via Forms.current', function () {
         var form = Forms.current,
           element = form.getElement('city'),

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -115,6 +115,43 @@ define([
       return new Promise(function (resolve) {
         setTimeout(resolve, ms);
       });
+    },
+
+    /**
+    @param {FormElementModel} element
+    @param {*} value
+    @returns {Promise}
+    */
+    confirmValueIsValid: function (element, value) {
+      var name = element.attributes.name;
+      element.val(value);
+      assert.notOk(element.validate(), name + ': no validation errors');
+      return mod.wait(600)
+      .then(function () {
+        var ul$ = element.attributes._view.$el.children('.bm-errors__bm-list');
+        assert.lengthOf(ul$, 0, name + ': view displays no errors');
+      });
+      return Promise.resolve();
+    },
+
+    /**
+    @param {FormElementModel} element
+    @param {*} value
+    @returns {Promise}
+    */
+    confirmValueIsInvalid: function (element, value, errors) {
+      var errors;
+      element.val(value);
+      errors = element.validate();
+      assert.ok(errors, element.attributes.name + ': has errors');
+      assert.ok(element.validationError, '.validationError set');
+      assert.isArray(errors.value);
+      return mod.wait(600)
+      .then(function () {
+        var ul$ = element.attributes._view.$el.children('.bm-errors__bm-list');
+        assert.lengthOf(ul$, 1, name + ': view displays errors');
+      });
+      return Promise.resolve();
     }
 
   };


### PR DESCRIPTION
There are several components to this fix.
- `Form` and `Element` base models override `Backbone.Model#isValid()` so that a "valid" event is emitted when validation passes. This allows validation rendering to specifically hook both validation events ("invalid" and "valid") instead of hooking "change:value". This, in turn, means validation rendering strictly happens _after_ validation, and never before.
- `Element#val()` used to have special validation behaviour, so consumers that use it instead of `Backbone.Model#set()` would have different behaviour. `Element` now overrides `Backbone.Model#set()` so value changes are treated consistently, regardless of consumer. Validation is always triggered if the "value" attribute was involved.
- `Date` view now correctly reacts to changes in the "_time" attribute on the model.
