### PR TITLE
FORMS-226 # Revert Selectbox to native selection

### DIFF
--- a/forms/jqm/elements/choicecollapsed.js
+++ b/forms/jqm/elements/choicecollapsed.js
@@ -23,7 +23,7 @@ define(function (require) {
       this.$el.empty();
       this.renderLabel();
 
-      $input = $('<select></select>');
+      this.$input = $input = $('<select></select>');
 
       if (type === 'select') {
         $input.attr({
@@ -39,12 +39,7 @@ define(function (require) {
         });
       }
 
-      if (attr.nativeMenu) {
-        $input.attr({'data-role': 'none'});
-      }
-
       this.$el.append($input);
-
       this.renderOptions();
       this.$el.fieldcontain();
 
@@ -58,7 +53,7 @@ define(function (require) {
       var $otherOption;
       var attrs = this.model.attributes;
       var type = attrs.type;
-      var $input = this.$el.find('select');
+      var $input = this.$input;
 
       $input.empty();
 
@@ -82,7 +77,7 @@ define(function (require) {
     onValueChange: function () {
       var renderOther = false;
       var attr = this.model.attributes;
-      var select = this.$el.find('select');
+      var select = this.$input;
 
       if (attr.type === 'select') {
         if ($.inArray(attr.value, _.keys(attr.options)) < 0) {
@@ -125,7 +120,7 @@ define(function (require) {
 
     fetchValue: function () {
       var attr = this.model.attributes;
-      var value = this.$el.find('select').val();
+      var value = this.$input.val();
 
       if (attr.type === 'select' && value === 'select one...' || _.contains(value, 'select one or more...')) {
         value = '';
@@ -134,12 +129,7 @@ define(function (require) {
     },
 
     onAttached: function () {
-      var attrs = this.model.attributes;
-      var select$ = this.$el.find('select');
-      var isEnhancementNeeded = !attrs.nativeMenu || attrs.type === 'multi';
-      if (isEnhancementNeeded && !this.$el.children('.ui-select').length) {
-        select$.selectmenu();
-      }
+      this.$input.selectmenu();
     }
   });
 

--- a/forms/models/elements/select.js
+++ b/forms/models/elements/select.js
@@ -19,11 +19,13 @@ define(function (require) {
 
   return Element.extend({
     defaults: defaults,
+
     initialize: function () {
       var attrs;
       Element.prototype.initialize.apply(this, arguments);
 
       attrs = this.attributes;
+      attrs.nativeMenu = attrs.type === 'select' && attrs.mode === 'collapsed';
 
       if (attrs.canSpecifyOther) {
         attrs.other = attrs.canSpecifyOther;

--- a/test/2_choices/test.js
+++ b/test/2_choices/test.js
@@ -48,12 +48,6 @@ define(['BlinkForms', 'testUtils', 'underscore'], function (Forms, testUtils, _)
         assert.notOk(element.val(), name + ': model value is falsey');
         // assert.lengthOf($selected, 0, name + ': nothing checked');
         assert.lengthOf($other, 0, name + ': other box absent');
-
-        if (element.get('nativeMenu')) {
-          assert.equal($view.find('select').data('role'), 'none', name + ': data-role is not none');
-        } else {
-          assert.notEqual($view.find('select').data('role'), 'none', name + ': data-role is not none');
-        }
       });
     });
 
@@ -146,20 +140,12 @@ define(['BlinkForms', 'testUtils', 'underscore'], function (Forms, testUtils, _)
         assert.notOk(element.val(), name + ': model value is falsey');
         assert.lengthOf($checked, 0, name + ': nothing checked');
         assert.lengthOf($other, 0, name + ': other box absent');
-
-        if (element.get('nativeMenu')) {
-          assert.equal($view.find('select').data('role'), 'none', name + ': data-role is not none');
-        } else {
-          assert.notEqual($view.find('select').data('role'), 'none', name + ': data-role is not none');
-        }
       });
     });
 
     test('Multi-F native collapsed', function () {
       var form = Forms.current,
-        element = form.getElement('multif'),
-        $fieldset = element.attributes._view.$el,
-        $select = $fieldset.find('select');
+        element = form.getElement('multif');
 
       element.val([]);
       assert.deepEqual(element.val(), [], 'model.value is []');
@@ -169,8 +155,6 @@ define(['BlinkForms', 'testUtils', 'underscore'], function (Forms, testUtils, _)
 
       element.val(['a', 'b']);
       assert.deepEqual(element.val(), ['a', 'b'], 'model.value = ["a", "b"]');
-
-      assert.equal($select.data('role'), 'none', 'data-role is not none');
     });
 
     ['boolean', 'question'].forEach(function (name) {
@@ -239,7 +223,7 @@ define(['BlinkForms', 'testUtils', 'underscore'], function (Forms, testUtils, _)
       });
     });
 
-    ['selectc', 'multic', 'multif', 'multig', 'multiee'].forEach(function (name) {
+    ['multic', 'multif', 'multig', 'multiee'].forEach(function (name) {
       test(name + ': model->view', function () {
         var form = Forms.current,
           element = form.getElement(name),
@@ -284,7 +268,7 @@ define(['BlinkForms', 'testUtils', 'underscore'], function (Forms, testUtils, _)
       });
     });
 
-    ['selectf', 'selecth'].forEach(function (name) {
+    ['selectc', 'selectf', 'selecth'].forEach(function (name) {
       test(name + ': model->view', function () {
         var form = Forms.current,
           element = form.getElement(name),
@@ -402,12 +386,6 @@ define(['BlinkForms', 'testUtils', 'underscore'], function (Forms, testUtils, _)
         assert.notOk(element.val(), name + ': model value is falsey');
         // assert.lengthOf($selected, 0, name + ': nothing checked');
         assert.lengthOf($other, 0, name + ': other box absent');
-
-        if (element.get('nativeMenu')) {
-          assert.equal($view.find('select').data('role'), 'none', name + ': data-role is not none');
-        } else {
-          assert.notEqual($view.find('select').data('role'), 'none', name + ': data-role is not none');
-        }
       });
     });
 
@@ -500,12 +478,6 @@ define(['BlinkForms', 'testUtils', 'underscore'], function (Forms, testUtils, _)
         assert.notOk(element.val(), name + ': model value is falsey');
         assert.lengthOf($checked, 0, name + ': nothing checked');
         assert.lengthOf($other, 0, name + ': other box absent');
-
-        if (element.get('nativeMenu')) {
-          assert.equal($view.find('select').data('role'), 'none', name + ': data-role is not none');
-        } else {
-          assert.notEqual($view.find('select').data('role'), 'none', name + ': data-role is not none');
-        }
       });
     });
 


### PR DESCRIPTION
- Change Select Model to detect a collapsed select box and turn on native
  menu
- Removed unneeded data-role attribute on select boxes from
  ChoiceCollapsed view
- Cache selectbox jQuery object on view
- Update onAttached to always enhance the select box

this update only touches on what would be combo boxes.  multiple selects and "expanded" selects are left alone

ux review from sam
