### PR TITLE
FORMS-248 # speed up population of sub-records

### DIFF
--- a/forms/jqm/elements/choicecollapsed.js
+++ b/forms/jqm/elements/choicecollapsed.js
@@ -115,7 +115,6 @@ define(function (require) {
         }
       }
       this.model.isValid();
-      this.renderErrors(this.model);
     },
 
     fetchValue: function () {

--- a/forms/jqm/elements/choiceexpanded.js
+++ b/forms/jqm/elements/choiceexpanded.js
@@ -150,7 +150,6 @@ define(function (require) {
         view.$el.find('input[type = text]').val(_.difference(value, _.keys(model.attributes.options)));
       }
       this.model.isValid();
-      this.renderErrors(this.model);
     },
 
     onSelectValueChange: function () {
@@ -182,7 +181,6 @@ define(function (require) {
         this.$el.find('input[type = text]').val(this.model.get('value'));
       }
       this.model.isValid();
-      this.renderErrors(this.model);
     },
 
     fetchValue: function () {

--- a/forms/jqm/elements/html.js
+++ b/forms/jqm/elements/html.js
@@ -56,7 +56,6 @@ define(function (require) {
       this.onPlaceholderChange();
 
       this.$el.fieldcontain();
-      this.renderErrors();
     },
 
     remove: function () {
@@ -104,7 +103,6 @@ define(function (require) {
       // #isValid() probably should be in the model, but we keep it here to
       // preserve a strict sequence: check THEN render
       this.model.isValid();
-      this.renderErrors();
     }
   });
 });

--- a/forms/jqm/elements/subform.js
+++ b/forms/jqm/elements/subform.js
@@ -66,7 +66,6 @@ define(function (require) {
     },
     onFormsChange: function () {
       var attrs,
-        view,
         $add,
         label,
         realLength;
@@ -87,19 +86,20 @@ define(function (require) {
         $add.button('disable');
       }
 
+      // make sure each SubForm model in the SubFormField's collection has a view
       this.model.attributes.forms.forEach(function (form) {
-        var body$, previous$, action;
-        // make sure each SubForm model in the SubFormField's collection has a view
-        action = form.attributes._action;
+        var body$, previous$;
+        var view = form.attributes._view;
+        var action = form.attributes._action;
 
         if (action !== 'remove') {
-          view = form.initializeView();
-
           if (!view || !view.$el || !view.$el.children().length) {
-            // prevent calling render() over and over as "add" buttons go crazy
+            // only call render() when necessary, otherwise "add" buttons go crazy
+            view = form.initializeView();
             form.$form = view.$el; // backwards-compatibility, convenience
             view.render();
           }
+
           body$ = view.$el.closest('body');
 
           if (!body$.length || body$[0] !== document.body) {

--- a/forms/jqm/elements/subform.js
+++ b/forms/jqm/elements/subform.js
@@ -113,7 +113,6 @@ define(function (require) {
           }
         }
       });
-      // this.$el.trigger('create');
     },
 
     onAttached: function () {

--- a/forms/jqm/page.js
+++ b/forms/jqm/page.js
@@ -5,14 +5,10 @@ define(function (require) {
 
   return SectionView.extend({
     tagName: 'section',
+
     initialize: function () {
-      var section = this.model;
-      this.$el.attr('data-name', section.attributes.name);
+      this.$el.attr('data-name', this.model.attributes.name);
       SectionView.prototype.initialize.call(this);
-    },
-    render: function () {
-      SectionView.prototype.render.call(this);
-      // this.$el.hide();
     }
   });
 });

--- a/forms/models/elements/subform.js
+++ b/forms/models/elements/subform.js
@@ -152,7 +152,6 @@ define(function (require) {
     },
 
     add: function (action) {
-      // TODO: there is too much DOM stuff here to be in the model
       var self = this;
       var attrs = this.attributes;
       var name = attrs.subForm;

--- a/forms/models/page.js
+++ b/forms/models/page.js
@@ -44,7 +44,6 @@ define(function (require) {
 
       attrs.elements = new Elements();
       // attrs._view = new Forms._views.Page({model: this});
-      this.initializeView();
 
       sections = form.attributes._sections;
 

--- a/test/27_1_generated/definitions.js
+++ b/test/27_1_generated/definitions.js
@@ -1,0 +1,5 @@
+define(['testUtils'], function (testUtils) {
+  return [
+    testUtils.generateBigFormDefinition()
+  ];
+});

--- a/test/27_1_generated/index.html
+++ b/test/27_1_generated/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <script src="../../node_modules/mocha/mocha.js"></script>
+    <script src="../../node_modules/grunt-mocha/phantomjs/bridge.js"></script>
+    <script src="http://d1c6dfkb81l78v.cloudfront.net/blink/require/6/require.min.js"></script>
+
+    <script src="../env-head.js"></script>
+</head>
+<body>
+<div data-role="page" data-url="/">
+    <header data-role="header"></header>
+    <div data-role="content" role="main"></div>
+    <footer data-role="footer"></footer>
+</div>
+<div id="mocha"></div>
+<script>
+    require(['test'], function () {
+        mocha.run();
+    });
+</script>
+</body>
+</html>

--- a/test/27_1_generated/test.js
+++ b/test/27_1_generated/test.js
@@ -1,0 +1,109 @@
+define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
+  suite('27: performance', function () {
+    var $page = $('[data-role=page]'),
+      $content = $page.find('[data-role=content]');
+
+    /**
+     * execute once before everything else in this suite
+     */
+    suiteSetup(function () {
+      $content.empty();
+      delete Forms.current;
+    });
+
+    suite('Form', function () {
+      test('BlinkForms global is an Object', function () {
+        assert($.isPlainObject(Forms), 'BlinkForms is a JavaScript object');
+      });
+
+      test('initialise with form.json', function () {
+        var form;
+
+        this.timeout(3e3); // default is 2e3, sometimes just need a bit longer
+
+        return Forms.getDefinition('test', 'add')
+        .then(function (def) {
+          console.time('initialize');
+          console.time('preloadPromise');
+
+          Forms.initialize(def);
+
+          console.timeEnd('initialize');
+
+          form = Forms.current;
+          assert.equal($.type(form), 'object');
+          assert.equal(form.get('name'), 'test');
+
+          return form.attributes.preloadPromise;
+        })
+        .then(function () {
+          console.timeEnd('preloadPromise');
+        });
+      });
+
+      test('render form for jQuery Mobile', function () {
+        var form = Forms.current;
+
+        console.time('append');
+        console.time('pageInjected');
+
+        Forms.once('pageInjected', function () {
+          console.timeEnd('pageInjected');
+        });
+
+        $content.append(form.$form);
+
+        console.timeEnd('append');
+
+        $.mobile.page({}, $page);
+
+        console.time('jQueryMobile enhance');
+
+        $page.trigger('pagecreate');
+        $page.show();
+
+        console.timeEnd('jQueryMobile enhance');
+      });
+
+      testUtils.defineLabelTest();
+
+      test('add subForm31 x4', function () {
+        console.time('add subForm31 x4');
+        return Forms.current.setRecord({
+          subForm31: [{}, {}, {}, {}]
+        })
+        .then(function () {
+          console.timeEnd('add subForm31 x4');
+        });
+      });
+
+      test('add subForm64 x4', function () {
+        console.time('add subForm64 x4');
+        return Forms.current.setRecord({
+          subForm64: [{}, {}, {}, {}]
+        })
+        .then(function () {
+          console.timeEnd('add subForm64 x4');
+        });
+      });
+
+      test('turn to page[1]', function (done) {
+        var calls = 0;
+        var onPageInjected = function () {
+          // should be 5 calls: apex + 4 sub-records
+          calls += 1;
+          if (calls === 5) {
+            Forms.off('pageInjected', onPageInjected);
+            console.timeEnd('turn to page[1]');
+            done();
+          }
+        };
+        this.timeout(3e3); // default is 2e3, sometimes just need a bit longer
+
+        console.time('turn to page[1]');
+        Forms.on('pageInjected', onPageInjected);
+        Forms.current.get('pages').goto(1);
+      });
+    }); // END: suite('Form', ...)
+  }); // END: suite('1', ...)
+});

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -152,6 +152,65 @@ define([
         assert.lengthOf(ul$, 1, name + ': view displays errors');
       });
       return Promise.resolve();
+    },
+
+    generateBigFormDefinition: function () {
+      var NAME = 'test';
+      var TYPES = ['text', 'textarea', 'number', 'date', 'time', 'boolean', 'location', 'file'];
+      var CHOICE_TYPES = ['select', 'multi'];
+      var page;
+      var def = {
+        default: {
+          name: NAME,
+          _elements: []
+        }
+      };
+      var OPTIONS = (function () {
+        var options = {};
+        var option;
+        while (Object.keys(options).length < 30) {
+          option = 'option' + (Object.keys(options).length + 1);
+          options[option] = option;
+        }
+        return options;
+      }());
+      var addTypedElements = function () {
+        TYPES.forEach(function (type) {
+          def.default._elements.push({
+            default: {
+              name: type + (def.default._elements.length + 1),
+              type: type,
+              page: page
+            }
+          });
+        });
+      };
+      var addChoiceElements = function () {
+        CHOICE_TYPES.forEach(function (type) {
+          def.default._elements.push({
+            default: {
+              name: type + (def.default._elements.length + 1),
+              type: type,
+              page: page,
+              options: OPTIONS
+            }
+          });
+        });
+      };
+      while (def.default._elements.length < 300) {
+        page = Math.floor(def.default._elements.length / 30);
+        addTypedElements();
+        def.default._elements.push({
+          default: {
+            name: 'subForm' + (def.default._elements.length + 1),
+            type: 'subForm',
+            page: page,
+            subForm: NAME
+          }
+        });
+        addChoiceElements();
+      }
+      return def;
     }
 
   };

--- a/test/sample-bic.js
+++ b/test/sample-bic.js
@@ -9,12 +9,11 @@ define([
   'underscore',
   'moment',
   'BlinkForms',
-  'definitions',
   'BMP.Blob',
   'BMP.BlinkGap',
   'feature!es5',
   'jquerymobile'
-], function (chai, Promise, $, _, moment, Forms, defs) {
+], function (chai, Promise, $, _, moment, Forms) {
   'use strict';
 
   var $submitPopup, $footer, $grid, $colB;
@@ -49,20 +48,22 @@ define([
 
   Forms.getDefinition = function (name, action) {
     return new Promise(function (resolve, reject) {
-      var def = _.find(defs, function (d) {
-        return d && d.default && d.default.name === name;
-      });
-      if (!def) {
-        reject(def);
-        return;
-      }
-      setTimeout(function () {
-        try {
-          resolve(Forms.flattenDefinition(def, action));
-        } catch (err) {
-          reject(err);
+      require(['definitions'], function (defs) {
+        var def = _.find(defs, function (d) {
+          return d && d.default && d.default.name === name;
+        });
+        if (!def) {
+          reject(def);
+          return;
         }
-      }, 100);
+        setTimeout(function () {
+          try {
+            resolve(Forms.flattenDefinition(def, action));
+          } catch (err) {
+            reject(err);
+          }
+        }, 100);
+      });
     });
   };
 


### PR DESCRIPTION
- the biggest improvement here is that we previously would re-render all the pre-existing siblings of a new sub-record, and now we don't
  - this adds up quickly: adding 4 sub-records would previously cause 10 renders (1 + 2 + 3 + 4)
  - the savings are proportional to the number of sub-records, with 1 lonely sub-record having no improvement
  - tests show that the 4 sub-record case can see a 50%  reduction in time taken
- remove a few unnecessary calls to `#renderErrors()`
- removed a few comments, especially ones that no longer apply
- dropped the unnecessary layer of abstraction that was `PageView#render()`
  - having a function that just returns the result of another function is slightly wasteful
- dropped 2 unnecessary variable allocations from the `PageView` module
  - it does make sense to cache regularly accessed objects like `this.attributes` or `this.model`, but in this case we were only hitting it once
  - having temporary variables can improve legibility, but they do cause more work for the garbage collector
  - my feeling is that `PageView` is still pretty easy to read without the unnecessary variables, but there are many cases where having temporary variables improves maintainability so much that it's worth the (often) tiny hit to GC
