### PR TITLE
(chore) switch remaining modules to CommonJS-in-AMD style

### DIFF
--- a/forms/error-helpers.js
+++ b/forms/error-helpers.js
@@ -63,7 +63,7 @@ define(function (require) {
     return errorObject;
   }
 
-  blinkFormsError = {
+  return {
     /**
      * converts a forms error object to an error string
      * @type {string}
@@ -89,6 +89,4 @@ define(function (require) {
 
     fromBMP: blinkFormsErrorParser
   };
-
-  return blinkFormsError;
 });

--- a/forms/geo.js
+++ b/forms/geo.js
@@ -1,6 +1,8 @@
 /* eslint-disable new-cap */ // i18n functions are not constructors
-define(['@blinkmobile/geolocation'], function (geolocation) {
+define(function (require) {
   'use strict';
+
+  var geolocation = require('@blinkmobile/geolocation');
 
   return {
 

--- a/forms/jqm/elements/blob_readonly.js
+++ b/forms/jqm/elements/blob_readonly.js
@@ -1,14 +1,11 @@
-define([
-  'forms/jqm/elements/file'
-], function (FileElementView) {
+define(function (require) {
   'use strict';
-  var BlobReadOnlyElement;
 
-  BlobReadOnlyElement = FileElementView.extend({
+  var FileElementView = require('forms/jqm/elements/file');
+
+  return FileElementView.extend({
     renderControls: function () {
       // do nothing, we don't have controls for read-only
     }
   });
-
-  return BlobReadOnlyElement;
 });

--- a/forms/jqm/elements/boolean.js
+++ b/forms/jqm/elements/boolean.js
@@ -12,7 +12,7 @@ define(function (require) {
 
   // this module
 
-  var BooleanElementView = ElementView.extend({
+  return ElementView.extend({
     events: {
       'change [data-onchange="onChange"]': 'onChange'
     },
@@ -56,8 +56,5 @@ define(function (require) {
       input$.val(this.model.val());
       input$.slider().slider('refresh');
     }
-
   });
-
-  return BooleanElementView;
 });

--- a/forms/jqm/elements/button.js
+++ b/forms/jqm/elements/button.js
@@ -12,7 +12,7 @@ define(function (require) {
 
   // this module
 
-  var ButtonElementView = ElementView.extend({
+  return ElementView.extend({
     remove: function () {
       this.$el.children('.ui-btn').children('button').off('click');
       return ElementView.prototype.remove.call(this);
@@ -46,6 +46,4 @@ define(function (require) {
       $button.button();
     }
   });
-
-  return ButtonElementView;
 });

--- a/forms/jqm/elements/choice.js
+++ b/forms/jqm/elements/choice.js
@@ -12,7 +12,7 @@ define(function (require) {
 
   // this module
 
-  var ChoiceElementView = ElementView.extend({
+  return ElementView.extend({
 
     initialize: function () {
       ElementView.prototype.initialize.call(this);
@@ -67,8 +67,5 @@ define(function (require) {
 
       return values;
     }
-
   });
-
-  return ChoiceElementView;
 });

--- a/forms/jqm/elements/choicecollapsed.js
+++ b/forms/jqm/elements/choicecollapsed.js
@@ -12,7 +12,7 @@ define(function (require) {
 
   // this module
 
-  var ChoiceCollapsedElementView = ChoiceElementView.extend({
+  return ChoiceElementView.extend({
     render: function () {
       var that = this;
       var $input;
@@ -132,6 +132,4 @@ define(function (require) {
       this.$input.selectmenu();
     }
   });
-
-  return ChoiceCollapsedElementView;
 });

--- a/forms/jqm/elements/choiceexpanded.js
+++ b/forms/jqm/elements/choiceexpanded.js
@@ -12,7 +12,7 @@ define(function (require) {
 
   // this module
 
-  var ChoiceExpandedElementView = ChoiceElementView.extend({
+  return ChoiceElementView.extend({
     remove: function () {
       var type = this.attributes.type;
       if (type !== 'select') {
@@ -208,6 +208,4 @@ define(function (require) {
       return values;
     }
   });
-
-  return ChoiceExpandedElementView;
 });

--- a/forms/jqm/elements/date.js
+++ b/forms/jqm/elements/date.js
@@ -18,7 +18,7 @@ define(function (require) {
 
   // this module
 
-  var DateElementView = ElementView.extend({
+  return ElementView.extend({
     events: {
       'change [data-onchange="onDateVChange"]': 'onDateVChange',
       'change [data-onchange="onTimeVChange"]': 'onTimeVChange'
@@ -150,8 +150,5 @@ define(function (require) {
       var name = this.model.attributes.name;
       this.$el.find('input[name="' + name + '_time"]').val(this.model.get('_time'));
     }
-
   });
-
-  return DateElementView;
 });

--- a/forms/jqm/elements/file.js
+++ b/forms/jqm/elements/file.js
@@ -12,7 +12,7 @@ define(function (require) {
 
   // this module
 
-  var FileElementView, humanizeBytes;
+  var humanizeBytes;
 
   /**
    * @param {Number} size in bytes
@@ -33,7 +33,7 @@ define(function (require) {
     return size + ' ' + units[unitIndex];
   };
 
-  FileElementView = ElementView.extend({
+  return ElementView.extend({
     render: function () {
       this.renderLabel();
       this.renderControls();
@@ -121,8 +121,5 @@ define(function (require) {
         });
       }
     }
-
   });
-
-  return FileElementView;
 });

--- a/forms/jqm/elements/heading.js
+++ b/forms/jqm/elements/heading.js
@@ -11,7 +11,7 @@ define(function (require) {
 
   // this module
 
-  var HeadingElementView = ElementView.extend({
+  return ElementView.extend({
     tagName: 'header',
 
     // explicitly override super's modelEvents
@@ -61,6 +61,4 @@ define(function (require) {
       this.$el.fieldcontain();
     }
   });
-
-  return HeadingElementView;
 });

--- a/forms/jqm/elements/message.js
+++ b/forms/jqm/elements/message.js
@@ -11,7 +11,7 @@ define(function (require) {
 
   // this module
 
-  var MessageElementView = ElementView.extend({
+  return ElementView.extend({
     tagName: 'div',
 
     // explicitly override super's modelEvents
@@ -49,6 +49,4 @@ define(function (require) {
       }
     }
   });
-
-  return MessageElementView;
 });

--- a/forms/jqm/elements/multi_readonly.js
+++ b/forms/jqm/elements/multi_readonly.js
@@ -11,7 +11,7 @@ define(function (require) {
 
   // this module
 
-  var MultiReadOnlyElementView = ElementView.extend({
+  return ElementView.extend({
     render: function () {
       var self = this;
       var attrs = self.model.attributes;
@@ -34,6 +34,4 @@ define(function (require) {
       }, 100);
     }
   });
-
-  return MultiReadOnlyElementView;
 });

--- a/forms/jqm/elements/readonly.js
+++ b/forms/jqm/elements/readonly.js
@@ -12,7 +12,7 @@ define(function (require) {
 
   // this module
 
-  var ReadOnlyElementView = ElementView.extend({
+  return ElementView.extend({
 
     // extending super-super's modelEvents
     modelEvents: _.extend({}, ElementView.prototype.modelEvents, {
@@ -47,6 +47,4 @@ define(function (require) {
       }
     }
   });
-
-  return ReadOnlyElementView;
 });

--- a/forms/jqm/elements/select_readonly.js
+++ b/forms/jqm/elements/select_readonly.js
@@ -3,7 +3,7 @@ define(function (require) {
 
   var ElementView = require('forms/jqm/element');
 
-  var SelectReadOnlyElementView = ElementView.extend({
+  return ElementView.extend({
     render: function () {
       var self = this;
       var attrs = self.model.attributes;
@@ -20,6 +20,4 @@ define(function (require) {
       }, 100);
     }
   });
-
-  return SelectReadOnlyElementView;
 });

--- a/forms/jqm/elements/select_readonly.js
+++ b/forms/jqm/elements/select_readonly.js
@@ -1,5 +1,7 @@
-define(['forms/jqm/element'], function (ElementView) {
+define(function (require) {
   'use strict';
+
+  var ElementView = require('forms/jqm/element');
 
   var SelectReadOnlyElementView = ElementView.extend({
     render: function () {

--- a/forms/jqm/elements/slider.js
+++ b/forms/jqm/elements/slider.js
@@ -13,7 +13,7 @@ define(function (require) {
 
   // this module
 
-  var SliderElementView = NumberElementView.extend({
+  return NumberElementView.extend({
 
     // extending super-super's modelEvents
     modelEvents: _.extend({}, ElementView.prototype.modelEvents, {
@@ -79,6 +79,4 @@ define(function (require) {
       return NumberElementView.prototype.remove.call(this);
     }
   });
-
-  return SliderElementView;
 });

--- a/forms/jqm/form.js
+++ b/forms/jqm/form.js
@@ -15,7 +15,7 @@ define(function (require) {
 
   // this module
 
-  var FormView = Backbone.View.extend({
+  return Backbone.View.extend({
     tagName: 'form',
 
     attributes: {
@@ -145,8 +145,5 @@ define(function (require) {
     onChangedId: function () {
       this.$el.attr('data-record-id', this.model.getElement('id').val());
     }
-
   });
-
-  return FormView;
 });

--- a/forms/jqm/page.js
+++ b/forms/jqm/page.js
@@ -1,5 +1,7 @@
-define(['forms/jqm/section'], function (SectionView) {
+define(function (require) {
   'use strict';
+
+  var SectionView = require('forms/jqm/section');
 
   var PageView = SectionView.extend({
     tagName: 'section',

--- a/forms/jqm/page.js
+++ b/forms/jqm/page.js
@@ -3,7 +3,7 @@ define(function (require) {
 
   var SectionView = require('forms/jqm/section');
 
-  var PageView = SectionView.extend({
+  return SectionView.extend({
     tagName: 'section',
     initialize: function () {
       var section = this.model;
@@ -15,6 +15,4 @@ define(function (require) {
       // this.$el.hide();
     }
   });
-
-  return PageView;
 });

--- a/forms/jqm/popup.js
+++ b/forms/jqm/popup.js
@@ -9,7 +9,7 @@ define(function (require) {
   /**
    * Popup Base View. Intended to be used by other popup views.
    */
-  var PopupView = Backbone.View.extend({
+  return Backbone.View.extend({
     element: 'div',
 
     attributes: function () {
@@ -74,6 +74,4 @@ define(function (require) {
       });
     }
   });
-
-  return PopupView;
 });

--- a/forms/jqm/popups/confirm-popup.js
+++ b/forms/jqm/popups/confirm-popup.js
@@ -14,7 +14,7 @@ define(function (require) {
 
   // this module
 
-  var ConfirmPopup = PopupView.extend({
+  return PopupView.extend({
     template: _.template(template),
 
     className: 'bm-popup bm-confirm',
@@ -45,8 +45,5 @@ define(function (require) {
     onCancelClick: function () {
       this._reject(new Error('cancel'));
     }
-
   });
-
-  return ConfirmPopup;
 });

--- a/forms/jqm/section.js
+++ b/forms/jqm/section.js
@@ -7,7 +7,7 @@ define(function (require) {
 
   // this module
 
-  var SectionView = Backbone.View.extend({
+  return Backbone.View.extend({
     tagName: 'section',
     initialize: function () {
       var attrs = this.model.attributes;
@@ -67,6 +67,4 @@ define(function (require) {
       });
     }
   });
-
-  return SectionView;
 });

--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -21,9 +21,7 @@ define(function (require) {
 
   // this module
 
-  var Element;
-
-  Element = Backbone.Model.extend({
+  return Backbone.Model.extend({
     defaults: function () {
       return {
         page: 0,
@@ -356,6 +354,4 @@ define(function (require) {
       return el;
     }
   });
-
-  return Element;
 });

--- a/forms/models/elements/boolean.js
+++ b/forms/models/elements/boolean.js
@@ -1,11 +1,7 @@
-define(['forms/models/element'], function (Element) {
+define(function (require) {
   'use strict';
 
-  var BooleanElement = Element.extend({
-    initialize: function () {
-      Element.prototype.initialize.apply(this, arguments);
-    }
-  });
+  var Element = require('forms/models/element');
 
-  return BooleanElement;
+  return Element.extend({});
 });

--- a/forms/models/elements/button.js
+++ b/forms/models/elements/button.js
@@ -1,16 +1,12 @@
-define(['forms/models/element'], function (Element) {
+define(function (require) {
   'use strict';
 
   var $ = require('jquery');
 
-  var ButtonElement = Element.extend({
-    initialize: function () {
-      Element.prototype.initialize.apply(this, arguments);
-    },
+  var Element = require('forms/models/element');
 
+  return Element.extend({
     setDirty: $.noop,
     setPristine: $.noop
   });
-
-  return ButtonElement;
 });

--- a/forms/models/elements/draw.js
+++ b/forms/models/elements/draw.js
@@ -1,5 +1,7 @@
-define(['forms/models/elements/file'], function (FileElement) {
+define(function (require) {
   'use strict';
+
+  var FileElement = require('forms/models/elements/file');
 
   return FileElement.extend({
     initialize: function () {

--- a/forms/models/elements/draw.js
+++ b/forms/models/elements/draw.js
@@ -4,9 +4,6 @@ define(function (require) {
   var FileElement = require('forms/models/elements/file');
 
   return FileElement.extend({
-    initialize: function () {
-      FileElement.prototype.initialize.apply(this, arguments);
-    },
     initializeView: function () {
       var Forms = BMP.Forms;
       var view;

--- a/forms/models/elements/email.js
+++ b/forms/models/elements/email.js
@@ -11,7 +11,7 @@ define(function (require) {
 
   // this module
 
-  var EmailElement = TextElement.extend({
+  return TextElement.extend({
     initializeView: function () {
       var Forms = BMP.Forms;
       var View, view;
@@ -42,6 +42,4 @@ define(function (require) {
       return _.isEmpty(errors) ? undefined : errors;
     }
   });
-
-  return EmailElement;
 });

--- a/forms/models/elements/email.js
+++ b/forms/models/elements/email.js
@@ -12,9 +12,6 @@ define(function (require) {
   // this module
 
   var EmailElement = TextElement.extend({
-    initialize: function () {
-      TextElement.prototype.initialize.apply(this, arguments);
-    },
     initializeView: function () {
       var Forms = BMP.Forms;
       var View, view;

--- a/forms/models/elements/file.js
+++ b/forms/models/elements/file.js
@@ -11,7 +11,6 @@ define(function (require) {
 
   // this module
 
-  var FileElement;
   var cameraDestinationType;
 
   /*
@@ -46,7 +45,7 @@ define(function (require) {
   @property {boolean} readonly          - if true, BlobReadOnlyElement View will be used.
   @property {boolean} capture           - if true, and the device supports "getUserMedia", "WebRTCImageElement" View will be used.
 */
-  FileElement = ElementModel.extend({
+  return ElementModel.extend({
     defaults: function () {
       return _.assign(ElementModel.prototype.defaults.call(this), {
         height: 0,
@@ -181,8 +180,5 @@ override because super#validate() checks "value", and we need to check "blob"
         this.set('blob', blob);
       }
     }
-
   });
-
-  return FileElement;
 });

--- a/forms/models/elements/heading.js
+++ b/forms/models/elements/heading.js
@@ -6,7 +6,7 @@ define(function (require) {
 
   var ElementModel = require('forms/models/element');
 
-  var HeadingElement = ElementModel.extend({
+  return ElementModel.extend({
     defaults: function () {
       return _.assign(ElementModel.prototype.defaults.call(this), {
         persist: false,
@@ -45,6 +45,4 @@ define(function (require) {
     setDirty: $.noop,
     setPristine: $.noop
   });
-
-  return HeadingElement;
 });

--- a/forms/models/elements/hidden.js
+++ b/forms/models/elements/hidden.js
@@ -1,14 +1,11 @@
-define(['forms/models/element'], function (Element) {
+define(function (require) {
   'use strict';
 
-  var HiddenElement = Element.extend({
-    initialize: function () {
-      Element.prototype.initialize.apply(this, arguments);
-    },
+  var Element = require('forms/models/element');
+
+  return Element.extend({
     // no-op, we don't want views here
     initializeView: function () {},
     removeView: function () {}
   });
-
-  return HiddenElement;
 });

--- a/forms/models/elements/location.js
+++ b/forms/models/elements/location.js
@@ -8,7 +8,7 @@ define(function (require) {
 
   // this module
 
-  var LocationElement = Element.extend({
+  return Element.extend({
     initializeView: function () {
       var Forms = BMP.Forms;
       var view;
@@ -49,8 +49,5 @@ define(function (require) {
           return Promise.reject(error);
         });
     }
-
   });
-
-  return LocationElement;
 });

--- a/forms/models/elements/location.js
+++ b/forms/models/elements/location.js
@@ -9,9 +9,6 @@ define(function (require) {
   // this module
 
   var LocationElement = Element.extend({
-    initialize: function () {
-      Element.prototype.initialize.apply(this, arguments);
-    },
     initializeView: function () {
       var Forms = BMP.Forms;
       var view;

--- a/forms/models/elements/multi.js
+++ b/forms/models/elements/multi.js
@@ -12,7 +12,7 @@ define(function (require) {
 
   // this module
 
-  var MultiElement = SelectElement.extend({
+  return SelectElement.extend({
     initialize: function () {
       var attrs;
       SelectElement.prototype.initialize.call(this);
@@ -52,8 +52,5 @@ define(function (require) {
       }
       return attrs.other && _.isEqual(attrs.value, ['other']) && !_.contains(attrs.options, 'other');
     }
-
   });
-
-  return MultiElement;
 });

--- a/forms/models/elements/number.js
+++ b/forms/models/elements/number.js
@@ -13,7 +13,7 @@ define(function (require) {
 
   // this module
 
-  var NumberElement = Element.extend({
+  return Element.extend({
     initialize: function () {
       var self = this;
       var attrs = self.attributes;
@@ -141,6 +141,4 @@ define(function (require) {
       return _.isEmpty(errors) ? undefined : errors;
     }
   });
-
-  return NumberElement;
 });

--- a/forms/models/elements/password.js
+++ b/forms/models/elements/password.js
@@ -1,10 +1,9 @@
-define(['forms/models/elements/text'], function (TextElement) {
+define(function (require) {
   'use strict';
 
-  var PasswordElement = TextElement.extend({
-    initialize: function () {
-      TextElement.prototype.initialize.apply(this, arguments);
-    },
+  var TextElement = require('forms/models/elements/text');
+
+  return TextElement.extend({
     initializeView: function () {
       var Forms = BMP.Forms;
       var View, view;
@@ -21,6 +20,4 @@ define(['forms/models/elements/text'], function (TextElement) {
       return view;
     }
   });
-
-  return PasswordElement;
 });

--- a/forms/models/elements/telephone.js
+++ b/forms/models/elements/telephone.js
@@ -1,10 +1,9 @@
-define(['forms/models/element'], function (Element) {
+define(function (require) {
   'use strict';
 
-  var TelephoneElement = Element.extend({
-    initialize: function () {
-      Element.prototype.initialize.apply(this, arguments);
-    },
+  var Element = require('forms/models/element');
+
+  return Element.extend({
     initializeView: function () {
       var Forms = BMP.Forms;
       var View, view;
@@ -21,6 +20,4 @@ define(['forms/models/element'], function (Element) {
       return view;
     }
   });
-
-  return TelephoneElement;
 });

--- a/forms/models/elements/text.js
+++ b/forms/models/elements/text.js
@@ -12,9 +12,6 @@ define(function (require) {
   // this module
 
   var TextElement = Element.extend({
-    initialize: function () {
-      Element.prototype.initialize.apply(this, arguments);
-    },
     initializeView: function () {
       var Forms = BMP.Forms;
       var View, view;

--- a/forms/models/elements/text.js
+++ b/forms/models/elements/text.js
@@ -11,7 +11,7 @@ define(function (require) {
 
   // this module
 
-  var TextElement = Element.extend({
+  return Element.extend({
     initializeView: function () {
       var Forms = BMP.Forms;
       var View, view;
@@ -48,6 +48,4 @@ define(function (require) {
       return _.isEmpty(errors) ? undefined : errors;
     }
   });
-
-  return TextElement;
 });

--- a/forms/models/elements/textarea.js
+++ b/forms/models/elements/textarea.js
@@ -1,10 +1,9 @@
-define(['forms/models/elements/text'], function (TextElement) {
+define(function (require) {
   'use strict';
 
-  var TextAreaElement = TextElement.extend({
-    initialize: function () {
-      TextElement.prototype.initialize.apply(this, arguments);
-    },
+  var TextElement = require('forms/models/elements/text');
+
+  return TextElement.extend({
     initializeView: function () {
       var Forms = BMP.Forms;
       var View, view;
@@ -21,6 +20,4 @@ define(['forms/models/elements/text'], function (TextElement) {
       return view;
     }
   });
-
-  return TextAreaElement;
 });

--- a/forms/models/elements/url.js
+++ b/forms/models/elements/url.js
@@ -1,10 +1,9 @@
-define(['forms/models/elements/text'], function (TextElement) {
+define(function (require) {
   'use strict';
 
-  var URLElement = TextElement.extend({
-    initialize: function () {
-      TextElement.prototype.initialize.apply(this, arguments);
-    },
+  var TextElement = require('forms/models/elements/text');
+
+  return TextElement.extend({
     initializeView: function () {
       var Forms = BMP.Forms;
       var View, view;
@@ -21,6 +20,4 @@ define(['forms/models/elements/text'], function (TextElement) {
       return view;
     }
   });
-
-  return URLElement;
 });

--- a/forms/models/popup.js
+++ b/forms/models/popup.js
@@ -15,7 +15,7 @@ define(function (require) {
    * @property {string} [confirmButtonIcon="delete"] - The confirm button icon to use. See [jQuery Mobile](http://api.jquerymobile.com/1.3/icons/) for a list of icons.
    * @property {boolean} [dissmissible=true] - See [jQuery Mobile](http://api.jquerymobile.com/1.3/popup/#option-dismissible) for more details
    */
-  var PopupModel = Backbone.Model.extend({
+  return Backbone.Model.extend({
     defaults: function () {
       return {
         title: '',
@@ -31,6 +31,4 @@ define(function (require) {
       };
     }
   });
-
-  return PopupModel;
 });

--- a/forms/models/subform.js
+++ b/forms/models/subform.js
@@ -1,9 +1,11 @@
-define(['forms/models/form'], function (Form) {
+define(function (require) {
   'use strict';
+
+  var Form = require('forms/models/form');
 
   // this module
 
-  var SubForm = Form.extend({
+  return Form.extend({
     initialize: function () {
       this.parentElement = null;
       Form.prototype.initialize.call(this);
@@ -32,6 +34,4 @@ define(['forms/models/form'], function (Form) {
       this.unset('_view');
     }
   });
-
-  return SubForm;
 });


### PR DESCRIPTION
Additionally:
- drop a few unnecessary `#initialize()` abstractions that were simply passing through to super
- rather than assign a variable and then `return` it without using it otherwise, simply skip the temporary variable assignment
