### PR TITLE
FORMS-233 # remove all use of `delete` keyword

### DIFF
--- a/forms/jqm/section.js
+++ b/forms/jqm/section.js
@@ -53,9 +53,9 @@ define(function (require) {
       // not sure if this still needs to be here or not,
       // but don't see anything breaking
       this.$el.remove();
-      delete this.model;
-      delete this.$el;
-      delete this.el;
+      this.model = null;
+      this.$el = null;
+      this.el = null;
       return result;
     },
     onAttached: function () {

--- a/forms/main.js
+++ b/forms/main.js
@@ -112,9 +112,7 @@ define(function (require) {
     }
 
     parsed = Forms.parseClass(klass);
-    blacklist.forEach(function (prop) {
-      delete parsed[prop];
-    });
+    parsed = _.omit(parsed, blacklist);
 
     defaults = _.result(model, 'defaults', {});
     model.set(Forms.castPropertyValues(parsed, defaults));

--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -56,7 +56,7 @@ define(function (require) {
           section.add(this);
         } else {
           page.add(this);
-          delete attrs.section;
+          attrs.section = null;
         }
       }
 
@@ -178,14 +178,14 @@ define(function (require) {
       var attrs = this.attributes;
       if (attrs._view) {
         attrs._view.remove();
-        delete attrs._view;
+        attrs._view = null;
       }
     },
     close: function () {
       var attrs = this.attributes;
-      delete attrs.form;
-      delete attrs.page;
-      delete attrs.section;
+      attrs.form = null;
+      attrs.page = null;
+      attrs.section = null;
       this.off(null, null, this);
     },
     /**

--- a/forms/models/elements/multi.js
+++ b/forms/models/elements/multi.js
@@ -21,7 +21,7 @@ define(function (require) {
 
       if (attrs.canSpecifyOther) {
         attrs.other = attrs.canSpecifyOther;
-        delete attrs.canSpecifyOther;
+        attrs.canSpecifyOther = null;
       }
     },
 

--- a/forms/models/elements/select.js
+++ b/forms/models/elements/select.js
@@ -29,7 +29,7 @@ define(function (require) {
 
       if (attrs.canSpecifyOther) {
         attrs.other = attrs.canSpecifyOther;
-        delete attrs.canSpecifyOther;
+        attrs.canSpecifyOther = null;
       }
     },
     initializeView: function () {

--- a/forms/models/elements/subform.js
+++ b/forms/models/elements/subform.js
@@ -60,7 +60,7 @@ define(function (require) {
         if (attrs.preload !== 'no' && attrs.preloadNum) {
           attrs.preload = Number(attrs.preloadNum);
         } else if (attrs.preload === 'no') {
-          delete attrs.preload;
+          attrs.preload = null;
         }
       } else if (!isNaN(Number(attrs.preload))) {
         attrs.preload = Number(attrs.preload);

--- a/forms/models/form.js
+++ b/forms/models/form.js
@@ -96,7 +96,7 @@ define(function (require) {
         '_sections'
       ]);
       pages = this.attributes._pages;
-      delete this.attributes._pages;
+      this.attributes._pages = null;
       if (pages && _.isArray(pages)) {
         // TODO: allow pages to be redeclared per-action
         pages = new Pages(_.map(pages, function (p) {
@@ -108,7 +108,7 @@ define(function (require) {
       this.attributes.pages = pages;
 
       elements = this.attributes._elements;
-      delete this.attributes._elements;
+      this.attributes._elements = null;
       if (elements && _.isArray(elements)) {
         // TODO: allow pages to be redeclared per-action
         elements = _.map(elements, function (e) {
@@ -142,7 +142,7 @@ define(function (require) {
       this.attributes.preloadPromise = Promise.all(preloadPromises);
 
       behaviours = this.attributes._behaviours;
-      delete this.attributes._behaviours;
+      this.attributes._behaviours = null;
       if (behaviours && _.isArray(behaviours)) {
         // TODO: allow behaviours to be redeclared per-action
         behaviours = _.map(behaviours, function (b) {
@@ -179,9 +179,9 @@ define(function (require) {
       var attrs = this.attributes;
       if (attrs._view) {
         attrs._view.remove();
-        delete attrs._view;
+        attrs._view = null;
       }
-      delete this.$form;
+      this.$form = null;
       if (attrs.pages) {
         attrs.pages.forEach(function (page) {
           page.close();

--- a/forms/models/page.js
+++ b/forms/models/page.js
@@ -67,7 +67,7 @@ define(function (require) {
           }
         }
         if (!sectionAttrs.section instanceof Section) {
-          delete sectionAttrs.section;
+          sectionAttrs.section = null;
         }
       });
       attrs.sections = sections;
@@ -84,10 +84,10 @@ define(function (require) {
       var attrs = this.attributes;
       if (attrs._view) {
         attrs._view.remove();
-        delete attrs._view;
+        attrs._view = null;
       }
-      delete attrs.form;
-      delete attrs.section;
+      attrs.form = null;
+      attrs.section = null;
       attrs.elements.forEach(function (element) {
         // some combinations of lo-dash and backbone have broken .length
         // so we need to double-check that .forEach actually yielded something

--- a/forms/models/section.js
+++ b/forms/models/section.js
@@ -34,9 +34,9 @@ define(function (require) {
       var attrs = this.attributes;
       if (attrs._view) {
         attrs._view.remove();
-        delete attrs._view;
+        attrs._view = null;
       }
-      delete attrs.form;
+      attrs.form = null;
       attrs.elements.forEach(function (element) {
         element.close();
       });

--- a/test/17_main/test.js
+++ b/test/17_main/test.js
@@ -1,4 +1,6 @@
-define(['BlinkForms', 'sinon', 'BIC'], function (Forms, sinon) {
+define([
+  'backbone', 'BlinkForms', 'sinon', 'BIC'
+], function (Backbone, Forms, sinon) {
   suite('17: main', function () {
     test('BMP is defined', function () {
       assert.isDefined(window.BMP);
@@ -38,6 +40,20 @@ define(['BlinkForms', 'sinon', 'BIC'], function (Forms, sinon) {
 
     test('BMP.Forms.proxyUnbindFormElementEvents is a function', function () {
       assert.isFunction(window.BMP.Forms.proxyUnbindFormElementEvents);
+    });
+
+    test('BMP.Forms.setAttributesFromClass', function () {
+      var model = new Backbone.Model({
+        class: 'id: 123; name: def; label: DEF; css-class',
+        id: 123,
+        label: 'ABC',
+        name: 'abc'
+      });
+      BMP.Forms.setAttributesFromClass(model);
+      assert.equal(model.attributes.class, 'css-class');
+      assert.equal(model.attributes.id, 123, '"id" is blacklisted');
+      assert.equal(model.attributes.label, 'DEF');
+      assert.equal(model.attributes.name, 'abc', '"name" is blacklisted');
     });
 
     suite('Model defaults', function () {


### PR DESCRIPTION
- don’t use the `delete` keyword anywhere, as this can cause polymorphic de-optimisation (term?)
  - http://mrale.ph/blog/2015/01/11/whats-up-with-monomorphism.html
  - instead, just set property to `null`
- https://jsperf.com/delete-vs-undefined-vs-null
  - ops/sec is 1-2 orders of magnitude better in Chrome, Firefox and Safari
  - `undefined` and `null` are roughly equal in performance
  - I went with `null`, only because it’s probably going to be more obvious to debug later, compared to `undefined`
- `null` breaks compatibility with anything that specifically expected `undefined`
- testing doesn't show statistically reliable performance improvements: 2-3% over 5 test iterations
