### PR TITLE
FORMS-233 # don't use `Backbone.Model#unset()`

### DIFF
--- a/forms/collections/pages.js
+++ b/forms/collections/pages.js
@@ -38,7 +38,7 @@ define(function (require) {
           view = page.attributes._view;
           if (view) {
             view.remove();
-            page.unset('_view');
+            page.attributes._view = null;
           }
         }
       });

--- a/forms/jqm/element.js
+++ b/forms/jqm/element.js
@@ -99,7 +99,7 @@ define(function (require) {
         events.proxyUnbindEntityEvents(this, this.model, this.modelEvents);
       }
 
-      this.model.unset('_view');
+      this.model.attributes._view = null;
       return Backbone.View.prototype.remove.call(this);
     },
 

--- a/forms/jqm/form.js
+++ b/forms/jqm/form.js
@@ -54,7 +54,7 @@ define(function (require) {
         pages.current.attributes._view.remove();
       }
 
-      this.model.unset('_view');
+      this.model.attributes._view = null;
       this.stopListening(this.model.attributes.elements);
 
       return Backbone.View.prototype.remove.call(this);

--- a/forms/jqm/section.js
+++ b/forms/jqm/section.js
@@ -48,7 +48,7 @@ define(function (require) {
           el.attributes._view.remove();
         }
       });
-      this.model.unset('_view');
+      this.model.attributes._view = null;
       result = Backbone.View.prototype.remove.call(this);
       // not sure if this still needs to be here or not,
       // but don't see anything breaking

--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -24,6 +24,7 @@ define(function (require) {
   return Backbone.Model.extend({
     defaults: function () {
       return {
+        _view: null,
         page: 0,
         class: '',
         defaultValue: '',

--- a/forms/models/form.js
+++ b/forms/models/form.js
@@ -66,6 +66,7 @@ define(function (require) {
   Form = Backbone.Model.extend({
     defaults: function () {
       return {
+        _view: null,
         answerSpace: '',
         class: '',
         uuid: '',

--- a/forms/models/page.js
+++ b/forms/models/page.js
@@ -28,6 +28,7 @@ define(function (require) {
   Page = Backbone.Model.extend({
     defaults: function () {
       return {
+        _view: null,
         class: ''
       };
     },

--- a/forms/models/popups/webcam-popup.js
+++ b/forms/models/popups/webcam-popup.js
@@ -152,7 +152,7 @@ define(function (require) {
       }
 
       _.invoke(stream.getTracks(), 'stop');
-      this.unset('stream');
+      this.attributes.stream = null;
     }
   });
 });

--- a/forms/models/subform.js
+++ b/forms/models/subform.js
@@ -31,7 +31,7 @@ define(function (require) {
       if (this.attributes._view) {
         this.attributes._view.remove();
       }
-      this.unset('_view');
+      this.attributes._view = null;
     }
   });
 });

--- a/test/24_images_multiplepages/test.js
+++ b/test/24_images_multiplepages/test.js
@@ -69,7 +69,7 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
                 assert.lengthOf(view.children('figure').children('img'), 1);
               }
             } else {
-              assert.isUndefined(element.attributes._view);
+              assert.notOk(element.attributes._view);
             }
 
             done();
@@ -113,7 +113,7 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
                 assert.lengthOf(view.children('figure').children('img'), 1);
               }
             } else {
-              assert.isUndefined(element.attributes._view);
+              assert.notOk(element.attributes._view);
             }
 
             done();


### PR DESCRIPTION
- don’t use `Backbone.Model#unset()` anywhere (except for “value” and “blob”), as this will involve function execution (context switches) and also trigger `Backbone.Model` change events
  - http://jsperf.com/backbone-unset
  - ops/sec is 3-4 orders of magnitude better in Chrome, Firefox and Safari
- instead, just directly set the attribute value to `null`
- breaks compatibility with anyone expecting a change event for this situation,
  - it’s most likely that people want to know when a value is set, and don’t really care for when it is unset
- rendering 4 large sub-records seems to take 11% less time over 5 test iterations, but there's quite a bit of variance between the individual results
