### PR TITLE
FORMS-233 # don't use `Backbone.Model#get()`

### DIFF
--- a/forms/collections/elements.js
+++ b/forms/collections/elements.js
@@ -21,13 +21,13 @@ define(function (require) {
     var elements;
     if (!_.isEmpty(elementModel.validationError)) {
       err = {};
-      err[ elementModel.get('name') ] = _.map(elementModel.validationError.value, addErrorText);
+      err[ elementModel.attributes.name ] = _.map(elementModel.validationError.value, addErrorText);
       errorList.push(err);
     }
 
-    if (elementModel.get('forms')) {
-      errorList = elementModel.get('forms').reduce(function (errList, form) {
-        elements = form.get('elements');
+    if (elementModel.attributes.forms) {
+      errorList = elementModel.attributes.forms.reduce(function (errList, form) {
+        elements = form.attributes.elements;
         if (!elements) {
           return errList;
         }
@@ -129,8 +129,8 @@ define(function (require) {
 
       errors = this.reduce(function (memo, elementModel) {
         var subFormErrors;
-        if (elementModel.get('type') === 'subForm') {
-          subFormErrors = _.chain(elementModel.get('forms').invoke('getInvalidElements'))
+        if (elementModel.attributes.type === 'subForm') {
+          subFormErrors = _.chain(elementModel.attributes.forms.invoke('getInvalidElements'))
                             .compact()
                             .pluck('errors')
                             .flatten()

--- a/forms/jqm/element.js
+++ b/forms/jqm/element.js
@@ -47,8 +47,8 @@ define(function (require) {
 
     attributes: function () {
       return {
-        'data-name': this.model.get('name'),
-        'data-element-type': this.model.get('type'),
+        'data-name': this.model.attributes.name,
+        'data-element-type': this.model.attributes.type,
         'data-role': 'fieldcontain',
         'class': elementClassFromModelAttributes(this.model.attributes)
       };
@@ -69,8 +69,8 @@ define(function (require) {
 
       this.$el.data('model', elementModel);
 
-      if (elementModel.get('defaultValue')) {
-        this.$el.val(elementModel.get('defaultValue'));
+      if (elementModel.attributes.defaultValue) {
+        this.$el.val(elementModel.attributes.defaultValue);
       }
 
       if (this.modelEvents) {

--- a/forms/jqm/elements/button.js
+++ b/forms/jqm/elements/button.js
@@ -20,7 +20,7 @@ define(function (require) {
     render: function () {
       var $button,
         label;
-      var name = this.model.get('name');
+      var name = this.model.attributes.name;
       var attrs = this.model.attributes;
       var self = this;
 

--- a/forms/jqm/elements/choiceexpanded.js
+++ b/forms/jqm/elements/choiceexpanded.js
@@ -157,10 +157,10 @@ define(function (require) {
       var view = this;
       var $inputs = view.$el.find('input[type=radio],input[type=checkbox]');
 
-      if (_.contains(_.keys(this.model.get('options')), this.model.get('value'))) {
-        this.$el.find('[value = "' + this.model.get('value') + '"]').prop('checked', true);
+      if (_.contains(_.keys(this.model.attributes.options), this.model.attributes.value)) {
+        this.$el.find('[value = "' + this.model.attributes.value + '"]').prop('checked', true);
       } else {
-        if (this.model.get('value') === '') {
+        if (this.model.attributes.value === '') {
           this.$el.find('input:checked').prop('checked', false);
         } else {
           this.$el.find('[value = other]').prop('checked', true);
@@ -176,9 +176,9 @@ define(function (require) {
 
       this.renderOtherText(_.contains(values, 'other'));
 
-      if (!_.contains(_.keys(this.model.get('options')), this.model.get('value')) && this.model.get('value') !== 'other') {
+      if (!_.contains(_.keys(this.model.attributes.options), this.model.attributes.value) && this.model.attributes.value !== 'other') {
         // Also need to fill the text box back in, in addition to selecting radio
-        this.$el.find('input[type = text]').val(this.model.get('value'));
+        this.$el.find('input[type = text]').val(this.model.attributes.value);
       }
       this.model.isValid();
     },

--- a/forms/jqm/elements/date.js
+++ b/forms/jqm/elements/date.js
@@ -61,7 +61,7 @@ define(function (require) {
     },
 
     render: function () {
-      var type = this.model.get('type');
+      var type = this.model.attributes.type;
 
       this.$el.empty();
       this.renderLabel();
@@ -78,7 +78,7 @@ define(function (require) {
     },
 
     onAttached: function () {
-      var type = this.model.get('type');
+      var type = this.model.attributes.type;
 
       if (type !== 'time') {
         this.onDateMChange();
@@ -110,11 +110,11 @@ define(function (require) {
 
     onDateMChange: function () {
       var name = this.model.attributes.name;
-      var value = this.model.get('_date');
+      var value = this.model.attributes._date;
       var input = this.$el.find('input[name="' + name + '_date"]');
       var picker = input.pickadate('picker');
       var pickerValue;
-      var dateFormat = this.model.mapDateFormats[this.model.get('dateFormat')] || DEFAULT_FORMAT;
+      var dateFormat = this.model.mapDateFormats[this.model.attributes.dateFormat] || DEFAULT_FORMAT;
 
       try {
         this.model.isInvalidFormat(DEFAULT_FORMAT, value);
@@ -149,7 +149,7 @@ define(function (require) {
 
     onTimeMChange: function () {
       var name = this.model.attributes.name;
-      this.$el.find('input[name="' + name + '_time"]').val(this.model.get('_time'));
+      this.$el.find('input[name="' + name + '_time"]').val(this.model.attributes._time);
     }
   });
 });

--- a/forms/jqm/elements/date_pickadate.js
+++ b/forms/jqm/elements/date_pickadate.js
@@ -71,7 +71,7 @@ define(function (require) {
     },
 
     render: function () {
-      var type = this.model.get('type');
+      var type = this.model.attributes.type;
       var $label;
 
       if (!DatePickadateElement.pickadateParent) {

--- a/forms/jqm/elements/draw.js
+++ b/forms/jqm/elements/draw.js
@@ -72,7 +72,7 @@ define(function (require) {
       var windowY = $window.innerHeight();
 
       // $div.hide();
-      $div.find('[data-role=header] > h2').text(this.model.get('label'));
+      $div.find('[data-role=header] > h2').text(this.model.attributes.label);
       $(document.body).append($div);
       $div.find('canvas').attr({
         height: Math.min(Math.floor((windowX - 60) * 4 / 9), windowY - 60),

--- a/forms/jqm/elements/email.js
+++ b/forms/jqm/elements/email.js
@@ -13,7 +13,7 @@ define(function (require) {
 
   return HTMLElementView.extend({
     createElement: function () {
-      var name = this.model.get('name');
+      var name = this.model.attributes.name;
       var input$ = $('<input type="email" />');
       input$.attr('name', name);
       return input$;

--- a/forms/jqm/elements/html.js
+++ b/forms/jqm/elements/html.js
@@ -97,7 +97,7 @@ define(function (require) {
       } else {
         this.$input.val(value);
       }
-      if (this.model.get('isPristine')) {
+      if (this.model.attributes.isPristine) {
         return;
       }
       // #isValid() probably should be in the model, but we keep it here to

--- a/forms/jqm/elements/location.js
+++ b/forms/jqm/elements/location.js
@@ -51,7 +51,7 @@ define(function (require) {
     },
 
     setClearButton: function () {
-      var value = this.model.get('value');
+      var value = this.model.attributes.value;
       var $clearButton = this.$el.find('[data-action=clear]');
       if (value) {
         $clearButton.button('enable');
@@ -184,10 +184,10 @@ define(function (require) {
 
       self.constructor.disableLocationButton.bind(this)();
 
-      value = model.get('value');
+      value = model.attributes.value;
       if (_.isEmpty(value) || !value.latitude || !value.longitude) {
         model.getGeoLocation().then(function () { // onSuccess
-          value = model.get('currentlocation');
+          value = model.attributes.currentlocation;
           // set value for first time
           $div.find('input').val(JSON.stringify(value));
           LocationElementView.initializeMap(value, $div);

--- a/forms/jqm/elements/location_native.js
+++ b/forms/jqm/elements/location_native.js
@@ -102,14 +102,14 @@ define(function (require) {
       var model = this.model;
       var value;
 
-      value = model.get('value');
+      value = model.attributes.value;
 
       // disable button till location located
       self.constructor.disableLocationButton.bind(self)();
 
       if (_.isEmpty(value) || !value.latitude || !value.longitude) {
         model.getGeoLocation().then(function () { // onSuccess
-          value = model.get('currentlocation');
+          value = model.attributes.currentlocation;
           // set value for first time
           window.navigator.map.confirmLocation($.proxy(LocationNativeElementView.onSuccess, self), $.proxy(LocationNativeElementView.onFail, self), value);
           self.constructor.enableLocationButton.bind(self)();

--- a/forms/jqm/elements/password.js
+++ b/forms/jqm/elements/password.js
@@ -13,7 +13,7 @@ define(function (require) {
 
   return HTMLElementView.extend({
     createElement: function () {
-      var name = this.model.get('name');
+      var name = this.model.attributes.name;
       var input$ = $('<input type="password" />');
       input$.attr('name', name);
       return input$;

--- a/forms/jqm/elements/slider.js
+++ b/forms/jqm/elements/slider.js
@@ -26,7 +26,7 @@ define(function (require) {
       slider$ = this.$el.children('div.ui-slider');
       if (slider$.length) {
         // we are dealing with jQueryMobile-enhanced DOM structure
-        this.$input.val(this.model.get('value'));
+        this.$input.val(this.model.attributes.value);
         this.$input.slider();
         this.$input.slider('refresh');
       }
@@ -50,7 +50,7 @@ define(function (require) {
           var val, modelVal;
           this.$input = $(this).find('input');
           val = this.$input.val();
-          modelVal = self.model.get('value');
+          modelVal = self.model.attributes.value;
 
           if (modelVal !== val) {
             self.model.set('value', this.$input.val());
@@ -60,7 +60,7 @@ define(function (require) {
 
       this.$input.attr({
         name: name,
-        value: this.model.get('value')
+        value: this.model.attributes.value
       });
       ['min', 'max', 'step'].forEach(function (prop) {
         if ($.isNumeric(attrs[prop])) {

--- a/forms/jqm/elements/telephone.js
+++ b/forms/jqm/elements/telephone.js
@@ -13,7 +13,7 @@ define(function (require) {
 
   return HTMLElementView.extend({
     createElement: function () {
-      var name = this.model.get('name');
+      var name = this.model.attributes.name;
       var input$ = $('<input type="tel" />');
       input$.attr('name', name);
       return input$;

--- a/forms/jqm/elements/text.js
+++ b/forms/jqm/elements/text.js
@@ -13,7 +13,7 @@ define(function (require) {
 
   return HTMLElementView.extend({
     createElement: function () {
-      var name = this.model.get('name');
+      var name = this.model.attributes.name;
       var input$ = $('<input type="text" />');
       input$.attr('name', name);
       return input$;

--- a/forms/jqm/elements/textarea.js
+++ b/forms/jqm/elements/textarea.js
@@ -13,7 +13,7 @@ define(function (require) {
 
   return HTMLElementView.extend({
     createElement: function () {
-      var name = this.model.get('name');
+      var name = this.model.attributes.name;
       var input$ = $('<textarea></textarea>');
       input$.attr('name', name);
       return input$;

--- a/forms/jqm/elements/url.js
+++ b/forms/jqm/elements/url.js
@@ -13,7 +13,7 @@ define(function (require) {
 
   return HTMLElementView.extend({
     createElement: function () {
-      var name = this.model.get('name');
+      var name = this.model.attributes.name;
       var input$ = $('<input type="url" />');
       input$.attr('name', name);
       return input$;

--- a/forms/jqm/form.js
+++ b/forms/jqm/form.js
@@ -55,7 +55,7 @@ define(function (require) {
       }
 
       this.model.unset('_view');
-      this.stopListening(this.model.get('elements'));
+      this.stopListening(this.model.attributes.elements);
 
       return Backbone.View.prototype.remove.call(this);
     },
@@ -113,28 +113,28 @@ define(function (require) {
         var pageIdOfElement;
         var pageCollection;
 
-        pageCollection = this.model.get('pages');
+        pageCollection = this.model.attributes.pages;
 
 // this is pretty hacky but it means not re-writing the form/subform rendering system
-        if (elementModel.get('parentElement')) {
-          pageIdOfElement = elementModel.get('parentElement').get('page').index();
+        if (elementModel.attributes.parentElement) {
+          pageIdOfElement = elementModel.attributes.parentElement.attributes.page.index();
         } else {
-          pageIdOfElement = elementModel.get('page').index();
+          pageIdOfElement = elementModel.attributes.page.index();
         }
 
         if (pageCollection.current && pageIdOfElement !== pageCollection.current.index()) {
           pageCollection.goto(pageIdOfElement);
         }
 
-        elementModel.get('_view').scrollTo({ duration: 100 }).then(
-          function () { resolve(elementModel.get('_view')); },
+        elementModel.attributes._view.scrollTo({ duration: 100 }).then(
+          function () { resolve(elementModel.attributes._view); },
           function () { reject(new Error('Scroll Animaiton Failed')); }
        );
       }.bind(this));
     },
 
     onAttached: function () {
-      this.model.get('pages').current.attributes.elements.forEach(function (el) {
+      this.model.attributes.pages.current.attributes.elements.forEach(function (el) {
         var view = el.attributes._view;
         if (view && typeof view.onAttached === 'function') {
           view.onAttached();

--- a/forms/jqm/popups/webcam-popup.js
+++ b/forms/jqm/popups/webcam-popup.js
@@ -62,7 +62,7 @@ define(function (require) {
     },
 
     onConfirmClick: function () {
-      this._resolve(this.$canvas[0].toDataURL(this.model.get('destinationMimeType')));
+      this._resolve(this.$canvas[0].toDataURL(this.model.attributes.destinationMimeType));
     },
 
     onCancelClick: function () {
@@ -107,7 +107,7 @@ define(function (require) {
      * Applies the models orientation value to the video element
      */
     rotateVideo: function () {
-      var orientation = this.model.get('orientation');
+      var orientation = this.model.attributes.orientation;
       var rotateCSS = 'rotate(' + orientation + 'deg)';
       var paddingY = this.model.isPortrait() ? '0' : '13%';
       var paddingX = '0';
@@ -193,7 +193,7 @@ define(function (require) {
           ctx.drawImage(video, 0, 0);
       }
 
-      return this.$canvas[0].toDataURL(this.model.get('destinationMimeType'));
+      return this.$canvas[0].toDataURL(this.model.attributes.destinationMimeType);
     },
 
     cacheElements: function () {

--- a/forms/jqm/section.js
+++ b/forms/jqm/section.js
@@ -19,7 +19,7 @@ define(function (require) {
       var self = this;
 
       this.$el.empty();
-      this.model.get('elements').forEach(function (el) {
+      this.model.attributes.elements.forEach(function (el) {
         var view, type;
         type = el.attributes.type;
         if (!el.attributes._view && typeof el.initializeView === 'function') {
@@ -43,7 +43,7 @@ define(function (require) {
     },
     remove: function () {
       var result;
-      this.model.get('elements').forEach(function (el) {
+      this.model.attributes.elements.forEach(function (el) {
         if (el.attributes._view) {
           el.attributes._view.remove();
         }
@@ -59,8 +59,8 @@ define(function (require) {
       return result;
     },
     onAttached: function () {
-      this.model.get('elements').models.forEach(function (el) {
-        var view = el.get('_view');
+      this.model.attributes.elements.models.forEach(function (el) {
+        var view = el.attributes._view;
         if (typeof view.onAttached === 'function') {
           view.onAttached();
         }

--- a/forms/jqm/subform.js
+++ b/forms/jqm/subform.js
@@ -45,7 +45,7 @@ define(function (require) {
 
       this.$el.attr(
         'data-record-index',
-        parentElement.get('forms').indexOf(this.model)
+        parentElement.attributes.forms.indexOf(this.model)
      );
 
       this.$el.prepend($button);

--- a/forms/jqm/subformcollapse.js
+++ b/forms/jqm/subformcollapse.js
@@ -39,7 +39,7 @@ define(function (require) {
 
       this.$el.attr(
         'data-record-index',
-        this.model.parentElement.get('forms').indexOf(this.model)
+        this.model.parentElement.attributes.forms.indexOf(this.model)
       );
 
       this.model.parentElement.attributes.summaryPromise.then(function (names) {

--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -261,7 +261,7 @@ define(function (require) {
      */
     val: function (value) {
       if (value === undefined) {
-        return this.get('value');
+        return this.attributes.value;
       }
 
       this.set('value', value);

--- a/forms/models/elements/file.js
+++ b/forms/models/elements/file.js
@@ -67,7 +67,7 @@ define(function (require) {
 */
       this.on('change:value', function () {
         var value;
-        value = this.get('value');
+        value = this.attributes.value;
 
         if (value) {
           this.setBlobFromString(value);
@@ -95,14 +95,14 @@ define(function (require) {
     initializeView: function () {
       var Forms = BMP.Forms;
       var view;
-      var accept = this.get('accept') || '';
+      var accept = this.attributes.accept || '';
 
       this.removeView();
-      if (this.get('readonly')) {
+      if (this.attributes.readonly) {
         view = new Forms._views.BlobReadOnlyElement({model: this});
       } else if (BMP.BlinkGap.hasCamera() && accept.indexOf('image') === 0) {
         view = new Forms._views.BGImageElement({model: this});
-      } else if (this.getUserMediaPresent() && this.get('capture') === true) {
+      } else if (this.getUserMediaPresent() && this.attributes.capture === true) {
         view = new Forms._views.WebRTCImageElement({model: this});
       } else {
         view = new Forms._views.FileElement({model: this});

--- a/forms/models/elements/message.js
+++ b/forms/models/elements/message.js
@@ -32,7 +32,7 @@ define(function (require) {
      */
     val: function (value) {
       if (value === undefined) {
-        return this.get('html');
+        return this.attributes.html;
       }
       this.set('html', value);
       return value;

--- a/forms/models/elements/subform.js
+++ b/forms/models/elements/subform.js
@@ -159,7 +159,7 @@ define(function (require) {
       var Forms = BMP.Forms;
 
       // make a map of the field name properties so they are easy to match
-      var fieldProperties = _.reduce(self.get('_elements'), function (memo, element) {
+      var fieldProperties = _.reduce(self.attributes._elements, function (memo, element) {
         memo[element.id] = element;
 
         return memo;
@@ -187,7 +187,7 @@ define(function (require) {
 
             form = new SubFormModel(_.extend({}, def, {_elements: elements, _action: action}));
 
-            self.listenTo(form.get('elements'), 'invalid change:value change:blob', function () {
+            self.listenTo(form.attributes.elements, 'invalid change:value change:blob', function () {
               self.validate.apply(self, arguments);
               form.setDirty();
               self.setDirty();
@@ -240,14 +240,14 @@ define(function (require) {
       if (this.indexOf(form) === -1) {
         return; // invalid SubForm model, not part of this SubFrom Element
       }
-      if (form.get('_action') === 'edit') {
+      if (form.attributes._action === 'edit') {
         if (form.attributes._view) {
           form.attributes._view.remove();
-          this.stopListening(form.get('elements'));
+          this.stopListening(form.attributes.elements);
         }
         form.attributes = {
           _action: 'remove',
-          id: form.getElement('id').get('value')
+          id: form.getElement('id').attributes.value
         };
         forms.trigger('remove');
       } else {
@@ -400,7 +400,7 @@ define(function (require) {
         return counter;
       }
       forms.models.forEach(function (v) {
-        if (v.get('_action') !== 'remove') {
+        if (v.attributes._action !== 'remove') {
           counter++;
         }
       });
@@ -442,7 +442,7 @@ define(function (require) {
 
     setExternalErrors: function (elementErrorList, options) {
       // set errors on subforms
-      this.get('forms').invoke('setErrors', elementErrorList, options);
+      this.attributes.forms.invoke('setErrors', elementErrorList, options);
 
       // set errors on me.
       if (elementErrorList.errors) {

--- a/forms/models/form.js
+++ b/forms/models/form.js
@@ -21,7 +21,7 @@ define(function (require) {
   var invalidWrapperFn, isSubForm;
 
   function isVisible (elementModel) {
-    return !elementModel.get('hidden');
+    return !elementModel.attributes.hidden;
   }
 
   invalidWrapperFn = function (fn) {
@@ -32,7 +32,7 @@ define(function (require) {
       var results;
       var elements;
 
-      elements = this.get('elements');
+      elements = this.attributes.elements;
 
       if (!elements) {
         return undefined;
@@ -60,7 +60,7 @@ define(function (require) {
   };
 
   isSubForm = function (elementModel) {
-    return elementModel.get('type') === 'subForm';
+    return elementModel.attributes.type === 'subForm';
   };
 
   Form = Backbone.Model.extend({
@@ -203,7 +203,7 @@ define(function (require) {
     getPage: function (index) {
       var Forms = BMP.Forms;
       var Page = Forms._models.Page;
-      var pages = this.get('pages');
+      var pages = this.attributes.pages;
 
       // assume that by now it's okay to create vanilla Pages
       while (pages.length <= index) {
@@ -249,9 +249,9 @@ define(function (require) {
       if (!this.attributes.elements) {
         return undefined;
       }
-      return _.reduce(this.get('elements').filter(isSubForm), function (memo, elementModel) {
+      return _.reduce(this.attributes.elements.filter(isSubForm), function (memo, elementModel) {
         memo = memo || {}; // create in here so we return undefined if we have no subforms.
-        memo[elementModel.id] = elementModel.get('forms');
+        memo[elementModel.id] = elementModel.attributes.forms;
         return memo;
       }, undefined);
     },
@@ -438,7 +438,7 @@ define(function (require) {
      */
     /* eslint-disable no-unused-vars */ // stop eslint compaining about options and errorList not being used.
     setErrors: function (errorList, options) {
-      var elementsCollection = this.get('elements');
+      var elementsCollection = this.attributes.elements;
       var subForms = this.getSubforms();
 
       _.each(subForms, function (subForm, name) {

--- a/forms/models/popups/webcam-popup.js
+++ b/forms/models/popups/webcam-popup.js
@@ -84,7 +84,7 @@ define(function (require) {
      * @return {Boolean}
      */
     isPortrait: function () {
-      var orientation = this.get('orientation');
+      var orientation = this.attributes.orientation;
       return orientation === 0 || orientation % 180 === 0;
     },
 
@@ -97,8 +97,8 @@ define(function (require) {
     rotate: function (rotateBy) {
       var orientation;
 
-      rotateBy = rotateBy || this.get('rotateBy');
-      orientation = (this.get('orientation') + rotateBy);
+      rotateBy = rotateBy || this.attributes.rotateBy;
+      orientation = (this.attributes.orientation + rotateBy);
 
       this.set('orientation', orientation);
 
@@ -113,7 +113,7 @@ define(function (require) {
      * @return {Number}
      */
     getClampedOrientation: function () {
-      var rotation = this.get('orientation') % 360;
+      var rotation = this.attributes.orientation % 360;
       if (rotation < 0) {
         rotation = 360 + rotation;
       }
@@ -134,7 +134,7 @@ define(function (require) {
      * @return {string} - A Blob URL
      */
     streamToURL: function () {
-      var stream = this.get('stream');
+      var stream = this.attributes.stream;
       if (!stream) {
         return '';
       }
@@ -146,7 +146,7 @@ define(function (require) {
      * Stops the webcam stream(s)
      */
     stopStream: function () {
-      var stream = this.get('stream');
+      var stream = this.attributes.stream;
       if (!stream) {
         return;
       }


### PR DESCRIPTION
- don’t use `Backbone.Model#get()` anywhere, as this will involve function execution (context switches)
  - instead, just directly access the attribute value
- http://jsperf.com/backbone-get/3
  - ops/sec is 1-2 orders of magnitude better in Chrome, Firefox and Safari
- breaks compatibility with any code that overrides `#get()` in weird ways
  - within this project, there aren't any good reasons to override `#get()`, so this should be fine
