### PR TITLE
FORMS-233 # improve performance testing output

### DIFF
--- a/test/27_performance/test.js
+++ b/test/27_performance/test.js
@@ -14,15 +14,25 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
   // });
 
   suite('27: performance', function () {
-    var $page = $('[data-role=page]'),
-      $content = $page.find('[data-role=content]');
+    var $page = $('[data-role=page]');
+    var $content = $page.find('[data-role=content]');
+    var oldInitialize;
 
     /**
      * execute once before everything else in this suite
      */
     suiteSetup(function () {
-      $content.empty();
-      delete Forms.current;
+      return testUtils.loadViews().then(function () {
+        oldInitialize = Forms.initialize;
+        Forms.initialize = testUtils.decorateConsoleTime(oldInitialize, 'Forms.initialize()');
+
+        $content.empty();
+        delete Forms.current;
+      });
+    });
+
+    suiteTeardown(function () {
+      Forms.initialize = oldInitialize;
     });
 
     suite('Form', function () {
@@ -36,11 +46,7 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
         this.timeout(3e3); // default is 2e3, sometimes just need a bit longer
 
         Forms.getDefinition('inspection', 'add').then(function (def) {
-          console.time('initialize');
-
           Forms.initialize(def);
-
-          console.timeEnd('initialize');
 
           console.time('behavioursExecuted');
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -18,6 +18,10 @@ define([
       return navigator.userAgent.toLowerCase().indexOf('phantom') !== -1;
     },
 
+    loadViews: function () {
+      return promisedRequire('forms/jqm');
+    },
+
     loadForm: function (name, action) {
       var $page = $('[data-role=page]');
       var $content = $page.find('[data-role=content]');
@@ -174,13 +178,17 @@ define([
         }
         return options;
       }());
+      var isRequired = function () {
+        return def.default._elements.length % 2 === 0;
+      };
       var addTypedElements = function () {
         TYPES.forEach(function (type) {
           def.default._elements.push({
             default: {
               name: type + (def.default._elements.length + 1),
               type: type,
-              page: page
+              page: page,
+              required: isRequired()
             }
           });
         });
@@ -192,7 +200,8 @@ define([
               name: type + (def.default._elements.length + 1),
               type: type,
               page: page,
-              options: OPTIONS
+              options: OPTIONS,
+              required: isRequired()
             }
           });
         });
@@ -205,12 +214,23 @@ define([
             name: 'subForm' + (def.default._elements.length + 1),
             type: 'subForm',
             page: page,
+            required: isRequired(),
             subForm: NAME
           }
         });
         addChoiceElements();
       }
       return def;
+    },
+
+    decorateConsoleTime: function (fn, name) {
+      return function () {
+        var result;
+        console.time(name);
+        result = fn.apply(this, arguments);
+        console.timeEnd(name);
+        return result;
+      };
     }
 
   };


### PR DESCRIPTION
- 50% of fields in the generated definition have REQUIRED validation
- add a timed test to see how long it takes to pre-init processing for forms definitions takes
- add timers to `FormsView#onAttached()` and `Forms.initialize()`
- note: from the output, it looks like we're calling `#onAttached()` for Forms / Pages that are not visible, which is probably something that should be addressed
