### PR TITLE
FORMS-233 # consistent Model#removeView()

### DIFF
--- a/forms/collections/pages.js
+++ b/forms/collections/pages.js
@@ -35,11 +35,7 @@ define(function (require) {
           view.render();
           form.attributes._view.$el.append(view.el);
         } else {
-          view = page.attributes._view;
-          if (view) {
-            view.remove();
-            page.attributes._view = null;
-          }
+          page.removeView();
         }
       });
       currentPage = self.current;

--- a/forms/jqm/element.js
+++ b/forms/jqm/element.js
@@ -99,7 +99,6 @@ define(function (require) {
         events.proxyUnbindEntityEvents(this, this.model, this.modelEvents);
       }
 
-      this.model.attributes._view = null;
       return Backbone.View.prototype.remove.call(this);
     },
 

--- a/forms/jqm/elements/subform.js
+++ b/forms/jqm/elements/subform.js
@@ -29,11 +29,6 @@ define(function (require) {
       this.$el.children('.ui-btn').children('button').off('click');
       this.model.attributes.forms.off('change', this.onFormsChange, this);
       this.stopListening(this.model, 'invalid valid');
-      this.model.attributes.forms.forEach(function (form) {
-        if (form.attributes._view) {
-          form.attributes._view.remove();
-        }
-      });
       return ElementView.prototype.remove.call(this);
     },
     render: function () {

--- a/forms/jqm/form.js
+++ b/forms/jqm/form.js
@@ -44,17 +44,10 @@ define(function (require) {
     onInvalidChange: toggleClass('bm-form-invalid', 'isInvalid'),
 
     remove: function () {
-      var pages = this.model.attributes.pages;
-
       events.proxyUnbindFormElementEvents(this, this.model, this.formElementEvents);
       events.proxyBindEntityEvents(this, this.model, this.modelEvents);
       this.$el.removeData('model');
 
-      if (pages && pages.current && pages.current.attributes._view) {
-        pages.current.attributes._view.remove();
-      }
-
-      this.model.attributes._view = null;
       this.stopListening(this.model.attributes.elements);
 
       return Backbone.View.prototype.remove.call(this);

--- a/forms/jqm/section.js
+++ b/forms/jqm/section.js
@@ -43,16 +43,9 @@ define(function (require) {
     },
     remove: function () {
       var result;
-      this.model.attributes.elements.forEach(function (el) {
-        if (el.attributes._view) {
-          el.attributes._view.remove();
-        }
-      });
-      this.model.attributes._view = null;
       result = Backbone.View.prototype.remove.call(this);
       // not sure if this still needs to be here or not,
       // but don't see anything breaking
-      this.$el.remove();
       this.model = null;
       this.$el = null;
       this.el = null;

--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -85,6 +85,8 @@ define(function (require) {
       this.on('change:value', function () {
         this.setDirty();
       }, this);
+
+      // this causes problems if sub-record "remove" events are propagated
       this.on('remove', this.close, this);
     },
 
@@ -175,6 +177,7 @@ define(function (require) {
     updateWarning: function () {
       this.set('warning', this.warn());
     },
+
     removeView: function () {
       var attrs = this.attributes;
       if (attrs._view) {
@@ -182,8 +185,10 @@ define(function (require) {
         attrs._view = null;
       }
     },
+
     close: function () {
       var attrs = this.attributes;
+      this.removeView();
       attrs.form = null;
       attrs.page = null;
       attrs.section = null;

--- a/forms/models/elements/subform.js
+++ b/forms/models/elements/subform.js
@@ -111,6 +111,21 @@ define(function (require) {
       return view;
     },
 
+    removeView: function () {
+      this.attributes.forms.forEach(function (form) {
+        form.removeView();
+      });
+      return ElementModel.prototype.removeView.call(this);
+    },
+
+    close: function () {
+      this.removeView();
+      this.attributes.forms.forEach(function (form) {
+        form.close();
+      });
+      return ElementModel.prototype.close.call(this);
+    },
+
     getSummaryElements: function () {
       var name = this.attributes.subForm;
       var Forms = BMP.Forms;
@@ -244,13 +259,11 @@ define(function (require) {
         form = index;
       }
       if (this.indexOf(form) === -1) {
-        return; // invalid SubForm model, not part of this SubFrom Element
+        return; // invalid SubForm model, not part of this SubForm Element
       }
       if (form.attributes._action === 'edit') {
-        if (form.attributes._view) {
-          form.attributes._view.remove();
-          this.stopListening(form.attributes.elements);
-        }
+        this.stopListening(form.attributes.elements);
+        form.removeView();
         form.attributes = {
           _action: 'remove',
           id: form.getElement('id').attributes.value

--- a/forms/models/form.js
+++ b/forms/models/form.js
@@ -166,6 +166,19 @@ define(function (require) {
       }, 0);
     },
 
+    removeView: function () {
+      var attrs = this.attributes;
+      if (attrs.pages) { // sometimes there are no pages
+        attrs.pages.forEach(function (page) {
+          page.removeView();
+        });
+      }
+      if (attrs._view) {
+        attrs._view.remove();
+        attrs._view = null;
+      }
+    },
+
     isValid: modelValidation.isValid,
 
     /**
@@ -183,10 +196,7 @@ define(function (require) {
 
     close: function () {
       var attrs = this.attributes;
-      if (attrs._view) {
-        attrs._view.remove();
-        attrs._view = null;
-      }
+      this.removeView();
       this.$form = null;
       if (attrs.pages) {
         attrs.pages.forEach(function (page) {

--- a/forms/models/page.js
+++ b/forms/models/page.js
@@ -74,6 +74,7 @@ define(function (require) {
       attrs.sections = sections;
       this.on('remove', this.close, this);
     },
+
     initializeView: function () {
       var Forms = BMP.Forms;
       var view;
@@ -81,12 +82,24 @@ define(function (require) {
       view = new Forms._views.Page({model: this});
       this.set('_view', view);
     },
-    close: function () {
+
+    removeView: function () {
       var attrs = this.attributes;
+      attrs.sections.forEach(function (section) {
+        section.removeView();
+      });
+      attrs.elements.forEach(function (element) {
+        element.removeView();
+      });
       if (attrs._view) {
         attrs._view.remove();
         attrs._view = null;
       }
+    },
+
+    close: function () {
+      var attrs = this.attributes;
+      this.removeView();
       attrs.form = null;
       attrs.section = null;
       attrs.elements.forEach(function (element) {

--- a/forms/models/section.js
+++ b/forms/models/section.js
@@ -23,6 +23,7 @@ define(function (require) {
 
       this.on('remove', this.close, this);
     },
+
     initializeView: function () {
       var Forms = BMP.Forms;
       var view;
@@ -30,12 +31,17 @@ define(function (require) {
       view = new Forms._views.Section({model: this});
       this.set('_view', view);
     },
+
+    removeView: function () {
+      this.attributes.elements.forEach(function (element) {
+        element.removeView();
+      });
+      return Element.prototype.removeView.call(this);
+    },
+
     close: function () {
       var attrs = this.attributes;
-      if (attrs._view) {
-        attrs._view.remove();
-        attrs._view = null;
-      }
+      this.removeView();
       attrs.form = null;
       attrs.elements.forEach(function (element) {
         element.close();
@@ -43,6 +49,7 @@ define(function (require) {
 
       this.off('remove', this.close, this);
     },
+
     add: function (element) {
       this.attributes.elements.add(element);
     }

--- a/forms/models/subform.js
+++ b/forms/models/subform.js
@@ -36,11 +36,9 @@ define(function (require) {
       return view;
     },
 
-    removeView: function () {
-      if (this.attributes._view) {
-        this.attributes._view.remove();
-      }
-      this.attributes._view = null;
+    close: function () {
+      this.parentElement = null;
+      return Form.prototype.close.call(this);
     }
   });
 });

--- a/test/17_main/test.js
+++ b/test/17_main/test.js
@@ -56,6 +56,15 @@ define([
       assert.equal(model.attributes.name, 'abc', '"name" is blacklisted');
     });
 
+    test('Model#removeView() implemented where #initializeView() is', function () {
+      Object.keys(Forms._models).forEach(function (name) {
+        var Model = Forms._models[name];
+        if (Model.prototype.initializeView) {
+          assert.isFunction(Model.prototype.removeView, name + '#removeView()');
+        }
+      });
+    });
+
     suite('Model defaults', function () {
       function defaultsIsAFunctionTest (model, name) {
         return test(name + '.defaults is a function', function () {


### PR DESCRIPTION
- all Models that have a View now have a `#removeView()` method
- none of the Views `null`-out their Model's reference to themselves (the Views), leaving that up to the Model
- Models that have nested Models propagate calls to `#removeView()` to their nested Models
- remove a few places where Views were talking to other Views directly
- switch an `#on()` use in a View to `#listenTo()` instead, so that clean-up is better
