### PR TITLE
FORMS-254 # Subform error not clearing for parent subform

### DIFF
--- a/forms/jqm/element.js
+++ b/forms/jqm/element.js
@@ -174,13 +174,18 @@ define(function (require) {
     },
 
     renderErrors: function (model, validationErrors) {
-      var attrs = (model || this.model).attributes;
-      var errors = (model || this.model).validationError || validationErrors;
+      var attrs = model.attributes;
+      var errors = validationErrors || model.validationError;
       var list$ = this.$el.children('.bm-errors__bm-list');
       var new$;
 
       if (!attrs) {
         return; // not safe to run yet
+      }
+
+      if (model !== this.model){
+        // prevent function from running if event has come from another model (eg a subform's form element)
+        return;
       }
 
       if (!errors || !errors.value || !errors.value.length) {

--- a/forms/jqm/element.js
+++ b/forms/jqm/element.js
@@ -183,7 +183,7 @@ define(function (require) {
         return; // not safe to run yet
       }
 
-      if (model !== this.model){
+      if (model !== this.model) {
         // prevent function from running if event has come from another model (eg a subform's form element)
         return;
       }

--- a/forms/jqm/elements/choice.js
+++ b/forms/jqm/elements/choice.js
@@ -16,7 +16,7 @@ define(function (require) {
 
     initialize: function () {
       ElementView.prototype.initialize.call(this);
-      this.model.on('change:options', this.renderOptions, this);
+      this.listenTo(this.model, 'change:options', this.renderOptions);
     },
 
     renderOtherText: function (render) {

--- a/forms/jqm/elements/choicecollapsed.js
+++ b/forms/jqm/elements/choicecollapsed.js
@@ -46,7 +46,7 @@ define(function (require) {
       $input.on('change', function () {
         that.model.set('value', that.prepModelValue());
       });
-      this.model.on('change:value', this.onValueChange, this);
+      this.listenTo(this.model, 'change:value', this.onValueChange);
     },
 
     renderOptions: function () {

--- a/forms/jqm/elements/choiceexpanded.js
+++ b/forms/jqm/elements/choiceexpanded.js
@@ -43,11 +43,11 @@ define(function (require) {
       this._renderOptions();
 
       if (type === 'select') {
-        this.model.on('change:value', this.onSelectValueChange, this);
+        this.listenTo(this.model, 'change:value', this.onSelectValueChange);
         this.onSelectValueChange();
       } else { // type === 'multi'
         // bind custom handler for checkboxes <- array
-        this.model.on('change:value', this.onMultiValueChange, this);
+        this.listenTo(this.model, 'change:value', this.onMultiValueChange);
         this.onMultiValueChange();
       }
 

--- a/forms/jqm/elements/file.js
+++ b/forms/jqm/elements/file.js
@@ -41,14 +41,14 @@ define(function (require) {
 
       this.$el.fieldcontain();
 
-      this.model.on('change:blob', function () {
+      this.listenTo(this.model, 'change:blob', function () {
         this.model.updateWarning();
         if (_.isEmpty(this.model.attributes.warning)) {
           this.renderWarning();
         } else {
           this.renderFigure();
         }
-      }, this);
+      });
     },
 
     renderControls: function () {
@@ -105,8 +105,6 @@ define(function (require) {
 
     remove: function () {
       this.$el.children('input').off('change');
-      this.model.off('change:blob', this.renderFigure, this);
-      this.model.off('change:progress', this.renderProgress, this);
       return ElementView.prototype.remove.call(this);
     },
 

--- a/forms/jqm/elements/location.js
+++ b/forms/jqm/elements/location.js
@@ -47,7 +47,7 @@ define(function (require) {
 
       $button.find('button').button();
 
-      this.model.on('change:value', this.renderFigure, this);
+      this.listenTo(this.model, 'change:value', this.renderFigure);
     },
 
     setClearButton: function () {
@@ -106,12 +106,11 @@ define(function (require) {
 
     remove: function () {
       this.$el.children('button').off('click');
-      this.model.off('change:value', this.renderFigure, this);
       return ElementView.prototype.remove.call(this);
     },
 
     onAttached: function () {
-      this.model.on('change:value', this.setClearButton, this);
+      this.listenTo(this.model, 'change:value', this.setClearButton, this);
       this.setClearButton();
     }
   }, {

--- a/forms/jqm/elements/location_readonly.js
+++ b/forms/jqm/elements/location_readonly.js
@@ -10,7 +10,7 @@ define(function (require) {
       this.$el.empty();
       this.renderLabel();
 
-      this.model.on('change:value', this.renderFigure, this);
+      this.listenTo(this.model, 'change:value', this.renderFigure);
     }
   });
 });

--- a/forms/jqm/elements/slider.js
+++ b/forms/jqm/elements/slider.js
@@ -68,14 +68,13 @@ define(function (require) {
         }
       }.bind(this));
 
-      this.model.on('change:value', this.renderSlider, this);
+      this.listenTo(this.model, 'change:value', this.renderSlider);
       this.$el.fieldcontain();
       this.renderSlider();
     },
 
     remove: function () {
       this.$el.off('change');
-      this.model.off('change:value');
       return NumberElementView.prototype.remove.call(this);
     }
   });

--- a/forms/jqm/elements/subform.js
+++ b/forms/jqm/elements/subform.js
@@ -17,7 +17,7 @@ define(function (require) {
     initialize: function () {
       this.listenTo(this.model, 'update:fieldErrors', function () {
         this.renderErrors.apply(this, arguments);
-      }.bind(this));
+      });
 
       ElementView.prototype.initialize.apply(this, arguments);
     },
@@ -49,7 +49,7 @@ define(function (require) {
 
       this.$el.attr('data-form', attrs.subform);
       this.$el.prepend($button);
-      this.model.attributes.forms.on('add remove', this.onFormsChange, this);
+      this.listenTo(this.model.attributes.forms, 'add remove', this.onFormsChange);
       this.$el.fieldcontain();
       this.onFormsChange();
     },

--- a/forms/jqm/elements/subform.js
+++ b/forms/jqm/elements/subform.js
@@ -16,7 +16,7 @@ define(function (require) {
 
     initialize: function () {
       this.listenTo(this.model, 'valid invalid', function (model, errors) {
-        if (model.cid !== this.model.cid) {
+        if (model !== this.model) {
           return;
         }
         this.renderErrors(this.model, errors);

--- a/forms/jqm/elements/subform.js
+++ b/forms/jqm/elements/subform.js
@@ -15,7 +15,10 @@ define(function (require) {
     tagName: 'section',
 
     initialize: function () {
-      this.listenTo(this.model, 'valid invalid', function (errors) {
+      this.listenTo(this.model, 'valid invalid', function (model, errors) {
+        if (model.cid !== this.model.cid) {
+          return;
+        }
         this.renderErrors(this.model, errors);
       });
 

--- a/forms/jqm/elements/subform.js
+++ b/forms/jqm/elements/subform.js
@@ -15,8 +15,8 @@ define(function (require) {
     tagName: 'section',
 
     initialize: function () {
-      this.listenTo(this.model, 'update:fieldErrors', function () {
-        this.renderErrors.apply(this, arguments);
+      this.listenTo(this.model, 'valid invalid', function (errors) {
+        this.renderErrors(this.model, errors);
       });
 
       ElementView.prototype.initialize.apply(this, arguments);

--- a/forms/models/element.js
+++ b/forms/models/element.js
@@ -157,7 +157,7 @@ define(function (require) {
       this.setDirty();
 
       this.validationError = { value: _.uniq(errors.concat(elementErrorList).reverse()) };
-      this.trigger('invalid', this, elementErrorList);
+      this.trigger('invalid', this, this.validationError);
     },
 
     setDirty: modelStates.setDirty,

--- a/forms/models/elements/subform.js
+++ b/forms/models/elements/subform.js
@@ -354,7 +354,7 @@ define(function (require) {
       // making this is asynchronous is necessary
       setTimeout(function () {
         this.isValid();
-        this.attributes.errors = this.validationError;
+        this.set('errors', this.validationError);
       }.bind(this), 0);
     },
 

--- a/forms/models/elements/subform.js
+++ b/forms/models/elements/subform.js
@@ -93,12 +93,12 @@ define(function (require) {
         attrs.summaryPromise = this.getSummaryElements();
       }
 
-      this.attributes.forms.on('add remove', this.updateFieldErrors, this);
+      this.listenTo(this.attributes.forms, 'add remove', this.updateFieldErrors);
 
       // make sure that all form events are bubbled up through this subform
-      this.attributes.forms.on('all', function () {
+      this.listenTo(this.attributes.forms, 'all', function () {
         this.trigger.apply(this, arguments);
-      }, this);
+      });
     },
 
     initializeView: function () {

--- a/forms/models/elements/subform.js
+++ b/forms/models/elements/subform.js
@@ -95,11 +95,10 @@ define(function (require) {
 
       this.listenTo(this.attributes.forms, 'add remove', this.updateFieldErrors);
 
-      // make sure that all form events are bubbled up through this subform
+      // make sure that form valid/invalid events are bubbled up through this subform
       this.listenTo(this.attributes.forms, 'all', function (event) {
         if (event === 'valid' || event === 'invalid') {
           this.trigger.apply(this, arguments);
-          this.isValid();
         }
       });
     },
@@ -355,38 +354,8 @@ define(function (require) {
       // making this is asynchronous is necessary
       setTimeout(function () {
         this.isValid();
-        this.set('errors', this.validationError);
+        this.attributes.errors = this.validationError;
       }.bind(this), 0);
-    },
-
-    validateField: function (attrs) {
-      var forms;
-      var errors = {};
-      var realLength = this.getRealLength();
-      if (attrs === undefined) {
-        attrs = this.attributes;
-      }
-
-      forms = attrs.forms;
-
-      // check if there is any subform added
-      if (forms && (attrs.required && realLength === 0 || attrs.minSubforms && attrs.minSubforms === 1 && realLength === 0)) {
-        errors.value = errors.value || [];
-        errors.value.push({code: 'REQUIRED'});
-      }
-      // check for max subforms
-      if (forms && attrs.maxSubforms && realLength > attrs.maxSubforms) {
-        errors.value = errors.value || [];
-        errors.value.push({code: 'MAXSUBFORM', MAX: attrs.maxSubforms});
-      }
-      // check for min subforms
-      if (forms && attrs.minSubforms && attrs.minSubforms > 1 && realLength < attrs.minSubforms) {
-        errors.value = errors.value || [];
-        errors.value.push({code: 'MINSUBFORM', MIN: attrs.minSubforms});
-      }
-      if (!_.isEmpty(errors)) {
-        return errors;
-      }
     },
 
     getButtonLabel: function () {
@@ -415,33 +384,33 @@ define(function (require) {
 
     validate: function (attrs) {
       var forms;
-      var subformErrorCounter = 0;
-      var errors;
+      var errors = {};
+      var realLength = this.getRealLength();
+
       if (attrs === undefined) {
         attrs = this.attributes;
       }
 
-      errors = this.validateField(attrs) || {};
-
       forms = attrs.forms;
-      if (!forms) {
-        return _.isEmpty(errors) ? undefined : errors;
-      }
 
-      forms.models.forEach(function (frm) {
-        var err;
-        err = frm.getInvalidElements();
-        if (err && err.length) {
-          subformErrorCounter++;
-        }
-      });
-
-      // check if subform fields has any errors
-      if (subformErrorCounter > 0) {
+      // check if there is any subform added
+      if (forms && (attrs.required && realLength === 0 || attrs.minSubforms && attrs.minSubforms === 1 && realLength === 0)) {
         errors.value = errors.value || [];
-        errors.value.push({code: 'SUBFORM'});
+        errors.value.push({code: 'REQUIRED'});
       }
-      return _.isEmpty(errors) ? undefined : errors;
+      // check for max subforms
+      if (forms && attrs.maxSubforms && realLength > attrs.maxSubforms) {
+        errors.value = errors.value || [];
+        errors.value.push({code: 'MAXSUBFORM', MAX: attrs.maxSubforms});
+      }
+      // check for min subforms
+      if (forms && attrs.minSubforms && attrs.minSubforms > 1 && realLength < attrs.minSubforms) {
+        errors.value = errors.value || [];
+        errors.value.push({code: 'MINSUBFORM', MIN: attrs.minSubforms});
+      }
+      if (!_.isEmpty(errors)) {
+        return errors;
+      }
     },
 
     setExternalErrors: function (elementErrorList, options) {

--- a/forms/models/elements/subform.js
+++ b/forms/models/elements/subform.js
@@ -195,6 +195,11 @@ define(function (require) {
               self.setDirty();
               Forms.current.setDirty();
             });
+
+            form.on('remove', function () {
+              self.stopListening(form.attributes.elements);
+            });
+
             form.parentElement = self;
             if (forms) {
               forms.add(form);

--- a/forms/models/form.js
+++ b/forms/models/form.js
@@ -123,22 +123,27 @@ define(function (require) {
         elements = [];
       }
       this.attributes.elements = new Elements(elements);
-      // bubble element events up through the form model.
-      this.attributes.elements.on('all', function () {
-        this.trigger.apply(this, arguments);
-      }, this);
+      // bubble element valid/invalid events up through the form model.
+      this.listenTo(this.attributes.elements, 'all', function (event) {
+        /* eslint-disable no-fallthrough*/
+        /* eslint-disable default-case*/
+        switch (event) {
+          case 'invalid':
+            this.set({
+              'isInvalid': true
+            });
+          case 'valid':
+            this.trigger.apply(this, arguments);
+            break;
+        }
+        /* eslint-enable default-case */
+        /* eslint-enable no-fallthrough*/
+      });
 
       // if any child elements change, then we are dirty
-      this.attributes.elements.on('change:value change:blob', function () {
+      this.listenTo(this.attributes.elements, 'change:value change:blob', function () {
         this.setDirty();
-      }, this);
-
-      // if any child elements are invalid, then we are invalid
-      this.attributes.elements.on('invalid', function () {
-        this.set({
-          'isInvalid': true
-        });
-      }, this);
+      });
 
       this.attributes.preloadPromise = Promise.all(preloadPromises);
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "ssh://git@git.blinkm.co:40022/blinkmobile-internal/forms.git",
   "scripts": {
     "build": "grunt build",
-    "lint": "eslint --fix --cache .",
+    "lint": "eslint .",
     "test": "grunt test",
     "posttest": "npm run lint"
   },

--- a/test/30_Subforms_inside_subforms/test.js
+++ b/test/30_Subforms_inside_subforms/test.js
@@ -116,17 +116,17 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
               });
     });
 
-    test('subform change:value events bubble up to Forms.current', function (done) {
+    test('subform valid events bubble up to Forms.current', function (done) {
       var subform = Forms.current.getElement('second_level_test');
 
       subform.add()
               .then(function () {
-                Forms.current.on('change:value', function (model, val) {
+                Forms.current.once('valid', function (model, error) {
                   assert.equal(model.id, 'second_level_text');
-                  assert.equal(val, 123);
                   done();
                 });
-                Forms.current.getElement('second_level_text').val(123);
+                Forms.current.getElement('second_level_text').val('');
+                Forms.current.getElement('second_level_text').val('eee');
               });
     });
 
@@ -150,7 +150,7 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
                   });
     });
 
-    test('3rd level subform invalid events bubble up to Forms.current', function (done) {
+    test('3rd level subform valid events bubble up to Forms.current', function (done) {
       var subform = Forms.current.getElement('second_level_test');
 
       return subform.add() // add second level
@@ -160,9 +160,9 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
                   .then(function () {
                     var thirdLevelRequiredField = Forms.current.getElement('third_level_req');
 
-                    Forms.current.on('change:value', function (model, value) {
+                    Forms.current.once('valid', function (model, value) {
                       assert.equal(model.id, 'third_level_req');
-                      assert.equal(value, 'hello');
+                      assert.equal(model.attributes.value, 'hello');
                       done();
                     });
 


### PR DESCRIPTION
- Removed useless and expensive 'This subform has errors' Error message
  - Moved `updateFieldErrors` function into `validate`
  - Fixed up tests that expected the `SUBFORM` error
- only `invalid` and `valid` events propagate up from subforms to parent form
  - fixed events that tested for `change:value`. They now check for the `valid` event.
  - added a guard in these events so that listener only executes when it is bound to the model that triggered the event.
- Changed views from `model#on` to `view#listenTo` so that views can clean up after themselves automatically
