### PR TITLE
Forms-247 # Changing form field labels

### DIFF
--- a/forms/jqm/elements/choiceexpanded.js
+++ b/forms/jqm/elements/choiceexpanded.js
@@ -21,24 +21,36 @@ define(function (require) {
       return ChoiceElementView.prototype.remove.call(this);
     },
 
+    renderLabel: function () {
+      if (!this.$label) {
+        this.$label = $('<legend></legend>');
+      }
+
+      if (!this.$el.find(this.$label).length) {
+        this.$fieldset.prepend(this.$label);
+      }
+
+      this.$label.html(this.model.attributes.label || '');
+    },
+
     render: function () {
-      var $fieldset;
+      //var $fieldset;
       var attrs = this.model.attributes;
       var type = attrs.type;
 
       this.$el.empty();
 
-      $fieldset = $('<fieldset></fieldset>').attr({
+      this.$fieldset = $('<fieldset></fieldset>').attr({
         'data-role': 'controlgroup'
       });
       if (attrs.layout === 'horizontal') {
-        $fieldset.attr({
+        this.$fieldset.attr({
           'data-type': 'horizontal'
         });
       }
-      $fieldset.prepend($('<legend></legend>').text(attrs.label));
 
-      this.$el.append($fieldset);
+      this.$el.append(this.$fieldset);
+      this.renderLabel();
 
       this._renderOptions();
 
@@ -51,13 +63,13 @@ define(function (require) {
         this.onMultiValueChange();
       }
 
-      $fieldset.controlgroup();
+      this.$fieldset.controlgroup();
       this.$el.fieldcontain();
     },
 
     _renderOptions: function () {
       var self = this;
-      var $fieldset = this.$el.children('fieldset');
+      var $fieldset = this.$fieldset;
       var attrs = this.model.attributes;
       var type = attrs.type;
       var options = attrs.options;
@@ -105,7 +117,7 @@ define(function (require) {
 
       this.render();
       this.$el.find('label > input').checkboxradio();
-      this.$el.children('fieldset').controlgroup();
+      this.$fieldset.controlgroup();
       this.$el.fieldcontain();
       if (type === 'select') {
         this.onSelectValueChange();

--- a/forms/jqm/elements/choiceexpanded.js
+++ b/forms/jqm/elements/choiceexpanded.js
@@ -34,7 +34,6 @@ define(function (require) {
     },
 
     render: function () {
-      //var $fieldset;
       var attrs = this.model.attributes;
       var type = attrs.type;
 

--- a/forms/jqm/elements/choiceexpanded.js
+++ b/forms/jqm/elements/choiceexpanded.js
@@ -28,7 +28,7 @@ define(function (require) {
         this.$label = $('<legend></legend>');
       }
 
-      if (!this.$fieldset.find(this.$label).length) {
+      if (!$.contains(this.$fieldset[0], this.$label[0])) {
         this.$fieldset.prepend(this.$label);
       }
 

--- a/forms/jqm/elements/choiceexpanded.js
+++ b/forms/jqm/elements/choiceexpanded.js
@@ -18,6 +18,8 @@ define(function (require) {
       if (type !== 'select') {
         this.$el.find('input').off('click');
       }
+      this.$fieldset = null;
+
       return ChoiceElementView.prototype.remove.call(this);
     },
 
@@ -26,7 +28,7 @@ define(function (require) {
         this.$label = $('<legend></legend>');
       }
 
-      if (!this.$el.find(this.$label).length) {
+      if (!this.$fieldset.find(this.$label).length) {
         this.$fieldset.prepend(this.$label);
       }
 

--- a/forms/jqm/elements/heading.js
+++ b/forms/jqm/elements/heading.js
@@ -19,8 +19,7 @@ define(function (require) {
       'change:text': 'renderHeading',
       'change:smallText': 'renderSmallText',
       'change:class': 'onChangeClass',
-      'change:hidden': 'onChangeHidden',
-      'change:label': 'renderLabel'
+      'change:hidden': 'onChangeHidden'
     },
 
     initialize: function () {

--- a/test/00_unit/tests/models/element.js/test.js
+++ b/test/00_unit/tests/models/element.js/test.js
@@ -5,7 +5,7 @@
   everything except the file being tested should be mocked or stubbed out.
 */
 define(['models/element'],
-function (ElementModel /* change this to whatever you want */) {
+function (ElementModel) {
   'use strict';
 
   var noop = function () {};

--- a/test/2_choices/test.js
+++ b/test/2_choices/test.js
@@ -545,6 +545,41 @@ define(['BlinkForms', 'testUtils', 'underscore'], function (Forms, testUtils, _)
         });
       });
     });
+
+    suite('Expanded Choice Element', function () {
+      var originalLabel;
+      var model;
+      var elementContainerElement;
+      var labelElement;
+
+      suiteSetup(function () {
+        model = Forms.current.getElement('selecte');
+        elementContainerElement = $('div[data-name=selecte]');
+        labelElement = $('legend', elementContainerElement);
+        originalLabel = model.attributes.label;
+        model.set('label', 'A new Label &amp; text');
+      });
+
+      suiteTeardown(function () {
+        model.set('label', originalLabel);
+        elementContainerElement = null;
+        labelElement = null;
+      });
+
+      test('label element should be a <LEGEND> element', function () {
+        assert.lengthOf(labelElement, 1, 'Label should exist in');
+      });
+
+      test('Setting models label attribute correctly sets the label on the view', function () {
+        // make sure text is encoded properly
+        assert.strictEqual(labelElement.text(), 'A new Label & text');
+      });
+
+      test('There should not be a <LABEL> element in the container', function () {
+        // make sure no extra label field is added
+        assert.lengthOf(elementContainerElement.children('label'), 0);
+      });
+    });
   }); // END: suite('Form', ...)
 
   suite('change page', function () {


### PR DESCRIPTION
- Make ChoiceExpanded Views override the `#renderLabel()` function
- Cached the label in the view element for consistency with how other element labels are stored
- Remove `change:label` listener for Header Element Views
- Add tests for ChoiceExpanded Views
