### PR TITLE
FORMS-250 # Collapsed subform summary breaks on empty value

### DIFF
--- a/forms/jqm/subformcollapse.js
+++ b/forms/jqm/subformcollapse.js
@@ -77,7 +77,12 @@ define(function (require) {
 
     renderSummary: function () {
       var values = Object.keys(this.formElementEvents).map(function (name) {
-        return this.model.getElement(name).val();
+        var element = this.model.getElement(name);
+        if (!element) {
+          return undefined;
+        }
+
+        return element.val();
       }.bind(this));
       this.$summary.text(_.compact(values).join(', '));
     }

--- a/test/31_subforms_collapse/definitions.js
+++ b/test/31_subforms_collapse/definitions.js
@@ -50,7 +50,28 @@ define(function () {
               subForm: 'form2',
               rowClass: 'collapse:forms;label:Custom;',
               plusButtonLabel: "PLUS",
-              minusButtonLabel: "MINUS"
+              minusButtonLabel: "MINUS",
+              "_elements": {
+                "datetimenow": {
+                  "hide": "",
+                  "override": "",
+                  "type": "datetime",
+                  "id": "datetimenow"
+                },
+                'comment': {
+                  "hide": "",
+                  "override": "",
+                  "type": "textarea",
+                  "id": "comment"
+                },
+                'hidden-field': {
+                  "hide": "1",
+                  "override": "",
+                  "type": "textarea",
+                  "id": "hidden-field"
+                }
+
+              },
             }
           },
           {
@@ -128,6 +149,13 @@ define(function () {
           },
           {
             'default': {
+              name: 'hidden-field',
+              label: 'Hidden Comment',
+              type: 'textarea'
+            }
+          },
+          {
+            'default': {
               name: 'subsub',
               label: 'Sub Sub',
               type: 'subForm',
@@ -138,7 +166,7 @@ define(function () {
         ]
       },
       list: {
-        _elements: ['datetimenow', 'comment']
+        _elements: ['datetimenow', 'comment', 'hidden-field']
       }
     },
     {

--- a/test/31_subforms_collapse/test.js
+++ b/test/31_subforms_collapse/test.js
@@ -11,9 +11,20 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
         var el = BMP.Forms.current.getElement(name);
         assert(el.attributes.summaryPromise);
         return el.attributes.summaryPromise.then(function (names) {
-          assert.deepEqual(names, ['datetimenow', 'comment'], name);
+          assert.deepEqual(names, ['datetimenow', 'comment', 'hidden-field'], name);
         });
       }));
+    });
+
+    test('hidden fields do not throw a type error', function () {
+      var subform = Forms.current.getElement('comments');
+
+      assert.doesNotThrow(function () {
+        subform.add().then(function (newSubForm) {
+          // reset to default state
+          subform.remove(newSubForm);
+        });
+      });
     });
 
     suite('after #setRecord()', function () {


### PR DESCRIPTION
- Happens when a sub form field that is marked as 'L' in the forms builder is also marked as 'H' on a parent form.
- Collapsed subforms check for existance of element before trying to get its value for the subform summary
- Modify tests to include the trigger
