### PR TITLE
FORMS-265 # Form elements are drawn twice when you turn the page

### DIFF
--- a/forms/collections/pages.js
+++ b/forms/collections/pages.js
@@ -19,9 +19,15 @@ define(function (require) {
       var self, currentform, currentPage;
       var view;
       self = this;
+
       if (!_.isNumber(index)) {
         index = 0;
       }
+
+      if (self.current) {
+        self.current.removeView();
+      }
+
       self.current = null;
 
       self.current = this.at(index);
@@ -34,12 +40,6 @@ define(function (require) {
       view = currentPage.attributes._view;
       view.render();
       currentform.attributes._view.$el.append(view.el);
-
-      this.forEach(function (page, number) {
-        if (number !== index) {
-          page.removeView();
-        }
-      });
 
       pollUntil(function () {
         var aBody$;

--- a/test/33_pages_with_subforms/test.js
+++ b/test/33_pages_with_subforms/test.js
@@ -70,6 +70,16 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
         });
 
         testUtils.defineButtonTest();
+
+        test('Going to the same page does not re-initialise the page', function () {
+          var numButtons = $('[data-onclick="onAddClick"]').length;
+
+          gotoPage(1);
+          assert.lengthOf($('[data-onclick="onAddClick"]'), numButtons);
+
+          gotoPage(1);
+          assert.lengthOf($('[data-onclick="onAddClick"]'), numButtons);
+        });
       });
     });
   });


### PR DESCRIPTION
- Only call remove view on the previous page
- Add tests confirming subforms are not double rendered
