### PR TITLE
FORMS-272 # populate fields even when data has names that don't match case

### DIFF
--- a/forms/models/form.js
+++ b/forms/models/form.js
@@ -238,6 +238,17 @@ define(function (require) {
       }
       element = this.attributes.elements.get(name);
 
+      if (!element) {
+        // using .every() because .forEach() doesn't have early bail-out
+        this.attributes.elements.every(function (el) {
+          if (el.attributes.name.toLowerCase() === name.toLowerCase()) {
+            element = el;
+            return false;
+          }
+          return true;
+        });
+      }
+
       if (!element && name !== 'id') {
         // this is supposed to recursively search sub forms for an element.
         element = _.head(_.reduce(this.getSubforms(), function (memo, subForm) {

--- a/test/7_population/definitions.js
+++ b/test/7_population/definitions.js
@@ -38,6 +38,12 @@ define(function () {
           },
           {
             'default': {
+              name: 'UpperCase',
+              type: 'text'
+            }
+          },
+          {
+            'default': {
               name: 'comments',
               label: 'Comments',
               type: 'subForm',

--- a/test/7_population/test.js
+++ b/test/7_population/test.js
@@ -57,6 +57,33 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
       assert.equal(comment.val(), 'get a comb');
     });
 
+    suite('FORMS-272: record data that does not match field name case', function () {
+      var mismatchRecord = { uppercase: 'abcdef' };
+
+      suiteSetup(function (done) {
+        Forms.current.setRecord(mismatchRecord).then(function () {
+          done();
+        });
+      });
+
+      test('#getElement() is no longer case sensitive', function () {
+        var form = BMP.Forms.current;
+        ['UpperCase', 'uppercase', 'uPPERcASE'].forEach(function (name) {
+          var el = form.getElement(name);
+          assert.ok(el, 'bfe[' + name + ']');
+          assert.strictEqual(el, form.getElement('UpperCase'), 'bfe[' + name + ']');
+        });
+      });
+
+      test('record data that does not match field name case', function () {
+        var form = BMP.Forms.current;
+        var el = form.getElement('UpperCase');
+        assert.ok(el, 'bfe[' + name + ']');
+        assert.equal(el.val(), 'abcdef', 'bfe[' + name + ']: .val()');
+        assert.includes(el.attributes._view.$el.text(), 'abcdef');
+      });
+    });
+
     suite('comments.setRecords() with 3 subForms', function () {
       suiteSetup(function () {
         record = {

--- a/test/7_population/test.js
+++ b/test/7_population/test.js
@@ -80,7 +80,7 @@ define(['BlinkForms', 'testUtils'], function (Forms, testUtils) {
         var el = form.getElement('UpperCase');
         assert.ok(el, 'bfe[' + name + ']');
         assert.equal(el.val(), 'abcdef', 'bfe[' + name + ']: .val()');
-        assert.includes(el.attributes._view.$el.text(), 'abcdef');
+        assert.equal(el.attributes._view.$input.val(), 'abcdef', 'bfe[' + name + ']: $input.val()');
       });
     });
 


### PR DESCRIPTION
### Fixed
- FORMS-272: populate fields even when data has names that don't match case (#67, @jokeyrhyme)
  - HelpDesk: 4002-UDJX-6616
- FORMS-272: `Form#getElement(name)` is no longer case-sensitive
  - note: using a name with the wrong case (or is missing) is bad for performance
